### PR TITLE
force linefeeds

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,13 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+ 
+# Denote all files that are truly binary and should not be modified.
+*.exe binary
+*.dll binary
+*.pdb binary
+*.ico binary
+*.png binary
+*.jpg binary
+ 
+# Always use LF line endings on checkout.
+* eol=lf


### PR DESCRIPTION
Otherwise, docker build fails when you checkout on Windows unless the user has autocrlf=false in their configuration