### PR TITLE
Add .NET Core SDK 3.1 support

### DIFF
--- a/linux/base.Dockerfile
+++ b/linux/base.Dockerfile
@@ -78,6 +78,7 @@ RUN apt-get update && ACCEPT_EULA=Y apt-get install -y \
   dos2unix \
   dotnet-dev-1.0.1 \
   dotnet-sdk-2.2 \
+  dotnet-sdk-3.1 \
   emacs \
   iptables \
   iputils-ping \


### PR DESCRIPTION
I realize that you try not to have extensive software development tooling on the Cloud Shell, but it's odd that you have a version of .NET Core installed that has already reached [end of support](https://dotnet.microsoft.com/platform/support/policy/dotnet-core#lifecycle).

In this PR, I just added [.NET Core 3.1 SDK](https://docs.microsoft.com/en-us/dotnet/core/install/linux-ubuntu#install-the-sdk) to the list of installed packages. 

I didn't remove .NET Core 2.2 because I didn't know if you needed a proper deprecation strategy or had other packages depending on it.