### PR TITLE
Add the Azure CLI ai-examples extention

### DIFF
--- a/linux/tools.Dockerfile
+++ b/linux/tools.Dockerfile
@@ -16,6 +16,9 @@ RUN wget -nv https://azurecliprod.blob.core.windows.net/cloudshell-release/azure
   && dpkg -i azure-cli-latest.deb \
   && rm -f azure-cli-latest.deb
 
+# Install any Azure CLI extensions that should be included by default.
+RUN az extension add --name ai-examples -y
+
 # Download the latest terraform (AMD64), install to global environment.
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 51852D87348FFC4C \
   && TF_VERSION=$(curl -s https://checkpoint-api.hashicorp.com/v1/check/terraform | jq -r -M ".current_version") \


### PR DESCRIPTION
This PR adds the `ai-examples` extension to the Cloud Shell install as discussed with @edyoung. 

The extension replaces the built in examples seen when a user types `-h` or `--help` with ones selected by out model, which chooses them based on popularity and best matches with the intent of the command. It also adds examples to groups and commands that have no built in ones. If no example can be found or communication with the server fails, it defaults to the built in commands.

It was added as a separate step from the CLI in the Dockerfile since it is on it's own update cycle. If the team wishes to group all Azure CLI steps together, I can update it.