### PR TITLE
install pwsh 7.1

### DIFF
--- a/linux/powershell/setupPowerShell.ps1
+++ b/linux/powershell/setupPowerShell.ps1
@@ -112,6 +112,8 @@ try {
         PowerShellGet\Install-Module -Name AzurePSDrive @prodAllUsers   
         PowerShellGet\Install-Module -Name Az.GuestConfiguration -MaximumVersion $script:dockerfileDataObject.AzGuestConfigurationMaxVersion -ErrorAction SilentlyContinue @prodAllUsers
         PowerShellGet\Install-Module -Name Microsoft.PowerShell.UnixCompleters @prodAllUsers
+        PowerShellGet\Install-Module -AllowPreRelease -Force PSReadLine -Repository PSGallery # get psreadline beta
+        PowerShellGet\Install-Module -Name Az.Tools.Predictor -Repository PSGallery
 
         # Install PSCloudShell modules
         $tempDirectory = Microsoft.PowerShell.Management\Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath ([System.IO.Path]::GetRandomFileName())

--- a/linux/tools.Dockerfile
+++ b/linux/tools.Dockerfile
@@ -47,6 +47,13 @@ RUN curl -sSL https://github.com/cli/cli/releases/download/v1.1.0/gh_1.1.0_linux
   && dpkg -i /tmp/gh.deb \
   && rm /tmp/gh.deb
 
+# Temporarily rerun PowerShell install during tools build to pick up latest version
+RUN rm packages-microsoft-prod.deb \
+  && wget -nv -q https://packages.microsoft.com/config/debian/10/packages-microsoft-prod.deb \
+  && dpkg -i packages-microsoft-prod.deb \
+  && apt update \
+  && apt-get -y install powershell 
+
 RUN mkdir -p /usr/cloudshell
 WORKDIR /usr/cloudshell
 

--- a/tests/PSinLinuxCloudShellImage.Tests.ps1
+++ b/tests/PSinLinuxCloudShellImage.Tests.ps1
@@ -142,7 +142,8 @@ Describe "Various programs installed with expected versions" {
             "python3m-config", 
             "x86_64-linux-gnu-python3-config", 
             "x86_64-linux-gnu-python3m-config",
-            "linkerd-stable-2.8.1"
+            "linkerd-stable-2.8.1",
+            "linkerd-stable-2.9.0"
         )
 
         $missing = ($command_diffs | ? { $_ -like "<*" } | % { $_.Replace("< ", "") } | ? { $_ -notin $special}) -join ","        

--- a/tests/PSinLinuxCloudShellImage.Tests.ps1
+++ b/tests/PSinLinuxCloudShellImage.Tests.ps1
@@ -132,7 +132,18 @@ Describe "Various programs installed with expected versions" {
         $command_diffs = bash -c "compgen -c | sort -u > /tests/installed_commands && diff /tests/command_list /tests/installed_commands"
 
         # these may or may not be present depending on how tests were invoked
-        $special = @("profile.ps1", "PSCloudShellStartup.ps1", "dh_pypy", "dh_python3", "pybuild", "python3-config", "python3m-config", "x86_64-linux-gnu-python3-config", "x86_64-linux-gnu-python3m-config")
+        $special = @(
+            "profile.ps1", 
+            "PSCloudShellStartup.ps1", 
+            "dh_pypy", 
+            "dh_python3", 
+            "pybuild", 
+            "python3-config", 
+            "python3m-config", 
+            "x86_64-linux-gnu-python3-config", 
+            "x86_64-linux-gnu-python3m-config",
+            "linkerd-stable-2.8.1"
+        )
 
         $missing = ($command_diffs | ? { $_ -like "<*" } | % { $_.Replace("< ", "") } | ? { $_ -notin $special}) -join ","        
         $missing | Should -Be "" -Because "Commands '$missing' should be installed on the path but were not found. No commands should have been removed unexpectedly. If one really should be deleted, remove it from command_list"

--- a/tests/PSinLinuxCloudShellImage.Tests.ps1
+++ b/tests/PSinLinuxCloudShellImage.Tests.ps1
@@ -174,7 +174,10 @@ Describe "PowerShell Modules" {
 
         # Ensure only one version of every single module is installed
         # This test is required since we are pulling modules from multiple repositories and the modules themselves have interconnected dependencies
-        (Get-Module -ListAvailable | Group-Object Name | Where-Object { $_.Count -gt 1 } ) | Should -Be $null
+
+        $special = @("PSReadLine")
+
+        (Get-Module -ListAvailable | Group-Object Name | Where-Object { $_.Count -gt 1 } ) | Where-Object { $_.Name -notin $special} | Should -Be $null
 
     }
 


### PR DESCRIPTION
I want to include PowerShell 7.1 in the next update but we don't have time to roll out another update to the base image. So this overwrites the pwsh in the base with a newer one in the tools layer. This is a bit inefficient for image size unfortunately.