### PR TITLE
Added Exchange Module to Cloudshell

### DIFF
--- a/linux/powershell/setupPowerShell.ps1
+++ b/linux/powershell/setupPowerShell.ps1
@@ -114,6 +114,7 @@ try {
         PowerShellGet\Install-Module -Name Microsoft.PowerShell.UnixCompleters @prodAllUsers
         PowerShellGet\Install-Module -AllowPreRelease -Force PSReadLine -Repository PSGallery # get psreadline beta
         PowerShellGet\Install-Module -Name Az.Tools.Predictor -Repository PSGallery
+        PowerShellGet\Install-Module -Name ExchangeOnlineManagement -RequiredVersion 2.0.4-Preview7 -AllowPrerelease -Force
 
         # Install PSCloudShell modules
         $tempDirectory = Microsoft.PowerShell.Management\Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath ([System.IO.Path]::GetRandomFileName())


### PR DESCRIPTION
As a part of this change, I had published a version to Powershell gallery. Now I am incorporating this change so that the ExchangeOnlineManagement module is preinstalled for all the Cloudshell users.

Testing - As a part of testing, I had used the same command on Cloudshell's current version and tested the cmdlets functionality.