### PR TITLE
Update GitHub CLI (gh) version from 1.1.0 to 1.7.0

### DIFF
--- a/linux/tools.Dockerfile
+++ b/linux/tools.Dockerfile
@@ -45,8 +45,8 @@ COPY ./linux/terraform/terraform*  /usr/local/bin/
 RUN chmod 755 /usr/local/bin/terraform* && dos2unix /usr/local/bin/terraform*
 
 # github CLI
-RUN curl -sSL https://github.com/cli/cli/releases/download/v1.1.0/gh_1.1.0_linux_amd64.deb > /tmp/gh.deb \
-    && echo 6e894e248db2b9f8be24b2adee35ea3c458632c24a9ef881c5030108b5d3dc15 /tmp/gh.deb | sha256sum -c \
+RUN curl -sSL https://github.com/cli/cli/releases/download/v1.7.0/gh_1.7.0_linux_amd64.deb > /tmp/gh.deb \
+    && echo 1907a1094cb7eb5218ca4e22a27229849e9a2bfc07ad4e83e1cbf43487b9c1bc /tmp/gh.deb | sha256sum -c \
     && dpkg -i /tmp/gh.deb \
     && rm /tmp/gh.deb
 


### PR DESCRIPTION
docker build log for tools.Dockerfile (No Problem):

```
Step 9/23 : RUN curl -sSL https://github.com/cli/cli/releases/download/v1.7.0/gh_1.7.0_linux_amd64.deb > /tmp/gh.deb     && echo 1907a1094cb7eb5218ca4e22a27229849e9a2bfc07ad4e83e1cbf43487b9c1bc /tmp/gh.deb | sha256sum -c     && dpkg -i /tmp/gh.deb     && rm /tmp/gh.deb
 ---> Running in 9dded610043d
/tmp/gh.deb: OK
Selecting previously unselected package gh.
(Reading database ... 169711 files and directories currently installed.)
Preparing to unpack /tmp/gh.deb ...
Unpacking gh (1.7.0) ...
Setting up gh (1.7.0) ...
Processing triggers for man-db (2.8.5-2) ...
Removing intermediate container 9dded610043d
 ---> d79bc441d441
```