### PR TITLE
Enables non-zero exit code with Pester

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,12 @@ This repository has several uses:
 
 ```bash
 docker pull mcr.microsoft.com/azure-cloudshell:latest
+
+# for bash
 docker run -it mcr.microsoft.com/azure-cloudshell /bin/bash
+
+# for powershell
+docker run -it mcr.microsoft.com/azure-cloudshell /usr/bin/pwsh
 ```
 
 ### Differences between running locally and in Cloud Shell

--- a/tests/test.ps1
+++ b/tests/test.ps1
@@ -6,4 +6,4 @@ $ProgressPreference = "SilentlyContinue"
 
 cd /tests
 Install-Module -Name Pester -Force
-Invoke-Pester -Script PSinLinuxCloudShellImage.Tests.ps1
+Invoke-Pester -CI -Script PSinLinuxCloudShellImage.Tests.ps1


### PR DESCRIPTION
We are currently running into a problem where GitHub Actions does not throw an error even if Pester test cases fail. I explained more in the GitHub issue here: https://github.com/Azure/CloudShell/issues/91

In theory, as long as you provide a non-zero exit code to GitHub Actions, it should stop the workflow. More information: https://docs.github.com/en/actions/creating-actions/setting-exit-codes-for-actions