### PR TITLE
report back failed exit code from invoke-pester

### DIFF
--- a/tests/command_list
+++ b/tests/command_list
@@ -934,7 +934,6 @@ pygettext2.7
 pygettext3
 pygettext3.7
 pygmentize
-pyjwt
 python
 python2
 python2.7

--- a/tests/test.ps1
+++ b/tests/test.ps1
@@ -6,4 +6,4 @@ $ProgressPreference = "SilentlyContinue"
 
 cd /tests
 Install-Module -Name Pester -Force
-Invoke-Pester -Script PSinLinuxCloudShellImage.Tests.ps1
+Invoke-Pester -CI -Script PSinLinuxCloudShellImage.Tests.ps1


### PR DESCRIPTION
and remove reference to pyjwt
This includes a change from @darrentu . Wanted to fix the test at the same time.