### PR TITLE
Update GitHub CLI (gh) version from 1.7.0 to 1.8.1

### DIFF
--- a/linux/tools.Dockerfile
+++ b/linux/tools.Dockerfile
@@ -46,8 +46,8 @@ COPY ./linux/terraform/terraform*  /usr/local/bin/
 RUN chmod 755 /usr/local/bin/terraform* && dos2unix /usr/local/bin/terraform*
 
 # github CLI
-RUN curl -sSL https://github.com/cli/cli/releases/download/v1.7.0/gh_1.7.0_linux_amd64.deb > /tmp/gh.deb \
-    && echo 1907a1094cb7eb5218ca4e22a27229849e9a2bfc07ad4e83e1cbf43487b9c1bc /tmp/gh.deb | sha256sum -c \
+RUN curl -sSL https://github.com/cli/cli/releases/download/v1.8.1/gh_1.8.1_linux_amd64.deb > /tmp/gh.deb \
+    && echo 9354b1fa20334ef1cca55cac1db637684c00b9d889578269df256f04ea077acf /tmp/gh.deb | sha256sum -c \
     && dpkg -i /tmp/gh.deb \
     && rm /tmp/gh.deb
 


### PR DESCRIPTION
CI passed. The docker build log for tools.Dockerfile (No Problem):
```
Step 10/24 : RUN curl -sSL https://github.com/cli/cli/releases/download/v1.8.1/gh_1.8.1_linux_amd64.deb > /tmp/gh.deb     && echo 9354b1fa20334ef1cca55cac1db637684c00b9d889578269df256f04ea077acf /tmp/gh.deb | sha256sum -c     && dpkg -i /tmp/gh.deb     && rm /tmp/gh.deb
 ---> Running in 3866f7256e8a
/tmp/gh.deb: OK
Selecting previously unselected package gh.
(Reading database ... 171513 files and directories currently installed.)
Preparing to unpack /tmp/gh.deb ...
Unpacking gh (1.8.1) ...
Setting up gh (1.8.1) ...
Processing triggers for man-db (2.8.5-2) ...
Removing intermediate container 3866f7256e8a
```