### PR TITLE
Update GitHub CLI (gh) version from 1.8.1 to 1.9.2

### DIFF
--- a/linux/tools.Dockerfile
+++ b/linux/tools.Dockerfile
@@ -46,8 +46,8 @@ COPY ./linux/terraform/terraform*  /usr/local/bin/
 RUN chmod 755 /usr/local/bin/terraform* && dos2unix /usr/local/bin/terraform*
 
 # github CLI
-RUN curl -sSL https://github.com/cli/cli/releases/download/v1.8.1/gh_1.8.1_linux_amd64.deb > /tmp/gh.deb \
-    && echo 9354b1fa20334ef1cca55cac1db637684c00b9d889578269df256f04ea077acf /tmp/gh.deb | sha256sum -c \
+RUN curl -sSL https://github.com/cli/cli/releases/download/v1.9.2/gh_1.9.2_linux_amd64.deb > /tmp/gh.deb \
+    && echo 5837f21dcc9fb24129861510db6e648407fb309ca182db0a2fe6d8e04e50693c /tmp/gh.deb | sha256sum -c \
     && dpkg -i /tmp/gh.deb \
     && rm /tmp/gh.deb
 

--- a/tests/command_list
+++ b/tests/command_list
@@ -1150,6 +1150,7 @@ toe
 top
 touch
 tput
+tqdm
 tr
 trap
 troff


### PR DESCRIPTION
CI passed. 

The docker build log for tools.Dockerfile (No Problem):
```
Step 10/24 : RUN curl -sSL https://github.com/cli/cli/releases/download/v1.9.2/gh_1.9.2_linux_amd64.deb > /tmp/gh.deb     && echo 5837f21dcc9fb24129861510db6e648407fb309ca182db0a2fe6d8e04e50693c /tmp/gh.deb | sha256sum -c     && dpkg -i /tmp/gh.deb     && rm /tmp/gh.deb
 ---> Running in 6afa7ed67c1f
/tmp/gh.deb: OK
Selecting previously unselected package gh.
(Reading database ... 172249 files and directories currently installed.)
Preparing to unpack /tmp/gh.deb ...
Unpacking gh (1.9.2) ...
Setting up gh (1.9.2) ...
```

The test result of PSinLinuxCloudShellImage.Tests.ps1:
```
[+] /tests/PSinLinuxCloudShellImage.Tests.ps1 42.09s (41.38s|498ms)
Tests completed in 42.11s
Tests Passed: 32, Failed: 0, Skipped: 0 NotRun: 0
```
