### PR TITLE
@hoisjp Update GitHub CLI (gh) version from 1.9.2 to 1.10.3

### DIFF
--- a/linux/tools.Dockerfile
+++ b/linux/tools.Dockerfile
@@ -46,8 +46,8 @@ COPY ./linux/terraform/terraform*  /usr/local/bin/
 RUN chmod 755 /usr/local/bin/terraform* && dos2unix /usr/local/bin/terraform*
 
 # github CLI
-RUN curl -sSL https://github.com/cli/cli/releases/download/v1.9.2/gh_1.9.2_linux_amd64.deb > /tmp/gh.deb \
-    && echo 5837f21dcc9fb24129861510db6e648407fb309ca182db0a2fe6d8e04e50693c /tmp/gh.deb | sha256sum -c \
+RUN curl -sSL https://github.com/cli/cli/releases/download/v1.10.3/gh_1.10.3_linux_amd64.deb > /tmp/gh.deb \
+    && echo 15948c51146a7f8cdee2e939450dd1593fb2832b5801c2034bc818b62296767c /tmp/gh.deb | sha256sum -c \
     && dpkg -i /tmp/gh.deb \
     && rm /tmp/gh.deb
 

--- a/tests/command_list
+++ b/tests/command_list
@@ -205,6 +205,9 @@ curl
 cut
 dash
 date
+dbilogstrip
+dbiprof
+dbiproxy
 dbus-cleanup-sockets
 dbus-daemon
 dbus-monitor
@@ -240,6 +243,7 @@ df
 dh_autotools-dev_restoreconfig
 dh_autotools-dev_updateconfig
 dh_bash-completion
+dh_perl_dbi
 dh_python2
 diff
 diff3


### PR DESCRIPTION
CI passed.

The docker build log for tools.Dockerfile (No Problem):
```
Step 10/24 : RUN curl -sSL https://github.com/cli/cli/releases/download/v1.10.3/gh_1.10.3_linux_amd64.deb > /tmp/gh.deb     && echo 15948c51146a7f8cdee2e939450dd1593fb2832b5801c2034bc818b62296767c /tmp/gh.deb | sha256sum -c     && dpkg -i /tmp/gh.deb     && rm /tmp/gh.deb
 ---> Running in 42a078ac4f98
/tmp/gh.deb: OK
Selecting previously unselected package gh.
(Reading database ... 173156 files and directories currently installed.)
Preparing to unpack /tmp/gh.deb ...
Unpacking gh (1.10.3) ...
Setting up gh (1.10.3) ...
```

The test result of PSinLinuxCloudShellImage.Tests.ps1:
```
[+] /tests/PSinLinuxCloudShellImage.Tests.ps1 54.86s (54.12s|510ms)
Tests completed in 54.88s
Tests Passed: 32, Failed: 0, Skipped: 0 NotRun: 0
```