### PR TITLE
Allow installing latest teams module

### DIFF
--- a/linux/powershell/setupPowerShell.ps1
+++ b/linux/powershell/setupPowerShell.ps1
@@ -94,7 +94,7 @@ try {
         PowerShellGet\Install-Module -Name SHiPS @prodAllUsers    
         PowerShellGet\Install-Module -Name SQLServer -MaximumVersion $script:dockerfileDataObject.SQLServerModuleMaxVersion @prodAllUsers
         PowerShellGet\Install-Module -Name MicrosoftPowerBIMgmt -MaximumVersion $script:dockerfileDataObject.PowerBIMaxVersion @prodAllUsers
-        PowerShellGet\Install-Module -Name MicrosoftTeams -MaximumVersion 2.0.0 @prodAllUsers           
+        PowerShellGet\Install-Module -Name MicrosoftTeams @prodAllUsers           
     }
     else {
         # update libmi.so


### PR DESCRIPTION
The incompatibility between Azure PowerShell and MicrosoftTeams modules is now resolved, so latest Teams can be installed again.