### PR TITLE
Update GitHub CLI (gh) ver to the latest stable

### DIFF
--- a/linux/powershell/setupPowerShell.ps1
+++ b/linux/powershell/setupPowerShell.ps1
@@ -113,7 +113,14 @@ try {
         PowerShellGet\Install-Module -Name Microsoft.PowerShell.UnixCompleters @prodAllUsers
         PowerShellGet\Install-Module -AllowPreRelease -Force PSReadLine -Repository PSGallery # get psreadline beta
         PowerShellGet\Install-Module -Name Az.Tools.Predictor -Repository PSGallery
-        PowerShellGet\Install-Module -Name ExchangeOnlineManagement -RequiredVersion 2.0.4-Preview7 -AllowPrerelease -Force
+        PowerShellGet\Install-Module -Name ExchangeOnlineManagement -RequiredVersion 2.0.5 -Force
+
+        # With older base image builds, teams 1.1.6 is already installed 
+        if (Get-Module MicrosoftTeams -ListAvailable) {
+            Update-Module MicrosoftTeams -Force -Scope AllUsers
+        } else {
+            PowerShellGet\Install-Module -Name MicrosoftTeams @prodAllUsers     
+        }
 
         # Install PSCloudShell modules
         $tempDirectory = Microsoft.PowerShell.Management\Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath ([System.IO.Path]::GetRandomFileName())

--- a/linux/tools.Dockerfile
+++ b/linux/tools.Dockerfile
@@ -46,10 +46,10 @@ COPY ./linux/terraform/terraform*  /usr/local/bin/
 RUN chmod 755 /usr/local/bin/terraform* && dos2unix /usr/local/bin/terraform*
 
 # github CLI
-RUN curl -sSL https://github.com/cli/cli/releases/download/v1.10.3/gh_1.10.3_linux_amd64.deb > /tmp/gh.deb \
-    && echo 15948c51146a7f8cdee2e939450dd1593fb2832b5801c2034bc818b62296767c /tmp/gh.deb | sha256sum -c \
-    && dpkg -i /tmp/gh.deb \
-    && rm /tmp/gh.deb
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | gpg --dearmor -o /usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+    && apt update \
+    && apt install gh
 
 # Temporarily rerun PowerShell install during tools build to pick up latest version
 RUN rm packages-microsoft-prod.deb \

--- a/tests/command_list
+++ b/tests/command_list
@@ -130,7 +130,6 @@ cf
 cfdisk
 c++filt
 chage
-chardetect
 chattr
 chcon
 chcpu
@@ -794,6 +793,7 @@ node
 nodejs
 nohup
 nologin
+normalizer
 npm
 nproc
 npx


### PR DESCRIPTION
CI passed.

The docker build log for tools.Dockerfile (No Problem):

```
Selecting previously unselected package gh.
(Reading database ... 
(Reading database ... 5%
...
(Reading database ... 100%
(Reading database ... 173816 files and directories currently installed.)
Preparing to unpack .../archives/gh_1.12.1_amd64.deb ...
Unpacking gh (1.12.1) ...
Setting up gh (1.12.1) ...
```