### PR TITLE
use pwsh 7.2 rc

### DIFF
--- a/linux/tools.Dockerfile
+++ b/linux/tools.Dockerfile
@@ -52,11 +52,14 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | g
     && apt install gh
 
 # Temporarily rerun PowerShell install during tools build to pick up latest version
+# while we are using PWSH RC, use that instead of release version
 RUN rm packages-microsoft-prod.deb \
     && wget -nv -q https://packages.microsoft.com/config/debian/10/packages-microsoft-prod.deb \
     && dpkg -i packages-microsoft-prod.deb \
     && apt update \
-    && apt-get -y install powershell 
+    && apt-get -y install powershell-preview \
+    && rm /usr/bin/pwsh \
+    && ln -s /usr/bin/pwsh-preview /usr/bin/pwsh
 
 RUN mkdir -p /usr/cloudshell
 WORKDIR /usr/cloudshell

--- a/tests/PSinLinuxCloudShellImage.Tests.ps1
+++ b/tests/PSinLinuxCloudShellImage.Tests.ps1
@@ -22,7 +22,8 @@ Describe "Various programs installed with expected versions" {
     It "Static Versions" {
         # These programs are installed explicitly with specific versions
         $script:pmap["Node.JS"].Version | Should -Be '8.16.0'
-        $script:pmap["Jenkins X"].Version | Should -Be '1.3.107'        
+        $script:pmap["Jenkins X"].Version | Should -Be '1.3.107'
+        $script:pmap["PowerShell"].Version | Should -BeLike '7.2*'        
     }
 
     It "Some Versions Installed" {
@@ -62,7 +63,8 @@ Describe "Various programs installed with expected versions" {
             "python3m-config", 
             "x86_64-linux-gnu-python3-config", 
             "x86_64-linux-gnu-python3m-config",
-            "linkerd-stable.*"
+            "linkerd-stable.*",
+            "pwsh-preview"
         )
 
         $specialmatcher = ($special | % { "($_)"}) -join "|"


### PR DESCRIPTION
Now we have a release candidate of PowerShell 7.2, start using that in Cloud Shell.

RCs are in the preview channel so the executable and package are both called pwsh-preview. When GA version comes out we revert to the main package.