### PR TITLE
ACR link change

### DIFF
--- a/linux/tools.Dockerfile
+++ b/linux/tools.Dockerfile
@@ -5,7 +5,7 @@
 
 # To build yourself locally, override this location with a local image tag. See README.md for more detail
 
-ARG IMAGE_LOCATION=cdpxlinux.azurecr.io/artifact/b787066e-c88f-4e20-ae65-e42a858c42ca/official/azure/cloudshell:1.0.20201030.1.base.master.0e24a3b1
+ARG IMAGE_LOCATION=cdpxb787066ec88f4e20ae65e42a858c42ca00.azurecr.io/official/azure/cloudshell:1.0.20201030.1.base.master.0e24a3b1
 
 # Copy from base build
 FROM ${IMAGE_LOCATION}


### PR DESCRIPTION
The CDPx team may have changed the ACR to the different location. Our previous tools builds were unable to pick up the base image. The new change in the URL should fix the problem.