### PR TITLE
Add dependencies for rdbms-connect cli extension

### DIFF
--- a/linux/base.Dockerfile
+++ b/linux/base.Dockerfile
@@ -108,6 +108,7 @@ RUN apt-get update && bash ./aptinstall.sh \
   parallel \
   postgresql-client \
   python3 \
+  python3-dev \
   python3-pip \
   python3-venv \
   python3.7-dev \

--- a/linux/base.Dockerfile
+++ b/linux/base.Dockerfile
@@ -108,7 +108,6 @@ RUN apt-get update && bash ./aptinstall.sh \
   parallel \
   postgresql-client \
   python3 \
-  python3-dev \
   python3-pip \
   python3-venv \
   python3.7-dev \

--- a/linux/base.Dockerfile
+++ b/linux/base.Dockerfile
@@ -86,7 +86,6 @@ RUN apt-get update && bash ./aptinstall.sh \
   dotnet-runtime-3.1 \
   dotnet-sdk-3.1 \
   emacs \
-  gcc \
   iptables \
   iputils-ping \
   java-common \

--- a/linux/base.Dockerfile
+++ b/linux/base.Dockerfile
@@ -86,6 +86,7 @@ RUN apt-get update && bash ./aptinstall.sh \
   dotnet-runtime-3.1 \
   dotnet-sdk-3.1 \
   emacs \
+  gcc \
   iptables \
   iputils-ping \
   java-common \
@@ -93,6 +94,7 @@ RUN apt-get update && bash ./aptinstall.sh \
   less \
   libffi-dev \
   libssl-dev \
+  libpq-dev \
   locales \
   man-db \
   maven \

--- a/tests/command_list
+++ b/tests/command_list
@@ -837,6 +837,7 @@ perlivp
 perlthanks
 pg_basebackup
 pgbench
+pg_config
 pg_dump
 pg_dumpall
 pg_isready


### PR DESCRIPTION
Add dependencies for rdbms-connect azure-cli extension to make it available in Cloud Shell

RDBMS-connect module enables connecting and executing queries for the azure database for PostgreSQL and MySQL using Azure CLI commands. The module requires external library called 'psycopg2' and this library cannot be installed in ubuntu/debian environment without installing other dependencies in advance. Originally 3 dependencies were requested from CLI team (gcc, libpq-dev, and python3-dev) but through testing we've found installing libpq-dev was enough to enable the extension. 

How to test:
az postgres flexible-server connect --help
az mysql flexible-server connect --help