### PR TITLE
Add install location of dotnet tools to the environment path

### DIFF
--- a/linux/tools.Dockerfile
+++ b/linux/tools.Dockerfile
@@ -92,6 +92,7 @@ RUN wget -nv -q https://raw.githubusercontent.com/ansible-collections/azure/dev/
 
 # Add user's home directories to PATH at the front so they can install tools which
 # override defaults
+# Add dotnet tools to PATH so users can install a tool using dotnet tools and can execute that command from any directory
 ENV PATH ~/.local/bin:~/bin:~/.dotnet/tools:$PATH
 
 # Set AZUREPS_HOST_ENVIRONMENT 

--- a/linux/tools.Dockerfile
+++ b/linux/tools.Dockerfile
@@ -92,7 +92,7 @@ RUN wget -nv -q https://raw.githubusercontent.com/ansible-collections/azure/dev/
 
 # Add user's home directories to PATH at the front so they can install tools which
 # override defaults
-ENV PATH ~/.local/bin:~/bin:$PATH
+ENV PATH ~/.local/bin:~/bin:~/$HOME/.dotnet/tools/:$PATH
 
 # Set AZUREPS_HOST_ENVIRONMENT 
 ENV AZUREPS_HOST_ENVIRONMENT cloud-shell/1.0

--- a/linux/tools.Dockerfile
+++ b/linux/tools.Dockerfile
@@ -92,7 +92,7 @@ RUN wget -nv -q https://raw.githubusercontent.com/ansible-collections/azure/dev/
 
 # Add user's home directories to PATH at the front so they can install tools which
 # override defaults
-ENV PATH ~/.local/bin:~/bin:~/$HOME/.dotnet/tools/:$PATH
+ENV PATH ~/.local/bin:~/bin:~/.dotnet/tools:$PATH
 
 # Set AZUREPS_HOST_ENVIRONMENT 
 ENV AZUREPS_HOST_ENVIRONMENT cloud-shell/1.0


### PR DESCRIPTION
The user can install a tool using dotnet tools and can execute that command from any directory in Cloud Shell.