### PR TITLE
[New Package] Add .NET 6 runtime and SDK

### DIFF
--- a/linux/base.Dockerfile
+++ b/linux/base.Dockerfile
@@ -83,8 +83,6 @@ RUN apt-get update && bash ./aptinstall.sh \
   cifs-utils \
   dnsutils \
   dos2unix \
-  dotnet-runtime-3.1 \
-  dotnet-sdk-3.1 \
   emacs \
   iptables \
   iputils-ping \
@@ -262,7 +260,7 @@ RUN wget -nv -q https://packages.microsoft.com/config/debian/10/packages-microso
 
 # Install .NET 6
 # The Microsoft repository GPG keys are already registered in previous step (Install PowerShell)
-# Install .NET 6 runtime and SDK using apt-get
+# Install .NET 6 runtime, ASP.NET Core runtime and SDK using apt-get
 RUN bash ./aptinstall.sh \
   dotnet-runtime-6.0 \
   dotnet-sdk-6.0

--- a/linux/base.Dockerfile
+++ b/linux/base.Dockerfile
@@ -260,6 +260,13 @@ RUN wget -nv -q https://packages.microsoft.com/config/debian/10/packages-microso
   && apt update \
   && bash ./aptinstall.sh powershell 
 
+# Install .NET 6
+# The Microsoft repository GPG keys are already registered in previous step (Install PowerShell)
+# Install .NET 6 runtime, ASP.NET Core runtime and SDK using apt-get
+RUN bash ./aptinstall.sh \
+  dotnet-runtime-6.0 \
+  dotnet-sdk-6.0
+
 # PowerShell telemetry
 ENV POWERSHELL_DISTRIBUTION_CHANNEL CloudShell
 # don't tell users to upgrade, they can't

--- a/linux/base.Dockerfile
+++ b/linux/base.Dockerfile
@@ -262,7 +262,7 @@ RUN wget -nv -q https://packages.microsoft.com/config/debian/10/packages-microso
 
 # Install .NET 6
 # The Microsoft repository GPG keys are already registered in previous step (Install PowerShell)
-# Install .NET 6 runtime, ASP.NET Core runtime and SDK using apt-get
+# Install .NET 6 runtime and SDK using apt-get
 RUN bash ./aptinstall.sh \
   dotnet-runtime-6.0 \
   dotnet-sdk-6.0


### PR DESCRIPTION
## Request

Today, the Cloud Shell only includes the .NET Core 3.1 runtime and SDK. While this is still technically supported, it will reach [end of support](https://dotnet.microsoft.com/platform/support/policy/dotnet-core#lifecycle) later this year. Right now, .NET 6 is the latest LTS version of .NET and I think it should be included side-by-side with .NET Core 3.1.

## Justification

My main reasoning is that the latest version of .NET and C# supports [top-level statements](https://docs.microsoft.com/dotnet/csharp/fundamentals/program-structure/top-level-statements). In a scripting scenario, it's really nice to be able to write a 2-3 line app to do something with the SDK swiftly without a bunch of plumbing code that's required by .NET Core 3.1 today. 

With .NET 6, I could add a message to the queue with just this code and not 30+ lines of plumbing code making it much more useful for quick admin "scripts":

```bash
dotnet new console
dotnet add package Azure.Storage.Queues
az storage account show-connection-string --resource-group <resource-group-name> --name <storage-account-name> --output tsv
```

```csharp
using Azure.Storage.Queues;

QueueClient client = new("<storage-connection-string>", "<queue-name>");
await client.CreateIfNotExistsAsync();
await client.SendMessageAsync("<message-content>");
```

Of course, adding .NET 6 now will avoid the headache of .NET Core 3.1 reaching end of support in December.

## Implementation

Typically, I would add the ``dotnet-sdk-6.0`` and ``dotnet-runtime-6.0`` APT packages to your **base** Dockerfile image, but the [.NET 6 Debian 10 install instructions](https://docs.microsoft.com/dotnet/core/install/linux-debian#debian-10-) specify that the Microsoft package signing key should be added first. That key is already installed with the PowerShell packages, so I just plugged this in right after PowerShell.

## Validation

I checked the container image locally with the command ``dotnet --list-sdks``:

![image](https://user-images.githubusercontent.com/5067401/158917625-9534caf6-2fdb-41d1-bc18-30559b26d9b0.png)

Unfortunately, I could not get the test suite running on my local machine or in a CI build on GitHub. I'm not sure if I messed up my configuration.
