### PR TITLE
Modified code to stop using poshtestgallery

### DIFF
--- a/linux/powershell/setupPowerShell.ps1
+++ b/linux/powershell/setupPowerShell.ps1
@@ -55,8 +55,9 @@ function Install-LibMIFile {
 # Install Azure and AzureAD (Active Directory) modules
 # This function replaces the old poshtestgallery issue
 function Install-AzAndAzAdModules {
-    echo "Install-AzAndAdModules.."
-    mkdir temp && curl -o az-cmdlets.tar.gz -sSL "https://azpspackage.blob.core.windows.net/release/Az-Cmdlets-7.3.2.35305.tar.gz" 
+    Write-Output "Install-AzAndAdModules.."
+    mkdir temp
+    curl -o az-cmdlets.tar.gz -sSL "https://azpspackage.blob.core.windows.net/release/Az-Cmdlets-7.3.2.35305.tar.gz" 
     tar -xf az-cmdlets.tar.gz -C temp 
     rm az-cmdlets.tar.gz
     cd temp
@@ -67,17 +68,17 @@ function Install-AzAndAzAdModules {
     Write-Output "Source Location: $SourceLocation"
 
     $gallery = [guid]::NewGuid().ToString()
-    Write-Host "Registering temporary repository $gallery with InstallationPolicy Trusted..."
+    Write-Output "Registering temporary repository $gallery with InstallationPolicy Trusted..."
     Register-PSRepository -Name $gallery -SourceLocation $($pwd.providerPath) -PackageManagementProvider NuGet -InstallationPolicy Trusted
 
     try {
-        Write-Host "Installing Az..."
+        Write-Output "Installing Az..."
         Install-Module -Name Az -Repository $gallery -Scope AllUsers -AllowClobber -Force
-        Write-Host "Installing AzureAD.Standard.Preview..."
+        Write-Output "Installing AzureAD.Standard.Preview..."
         Install-Module -Name "AzureAD.Standard.Preview" -Repository $gallery -Scope AllUsers -AllowClobber -Force
     }
     finally {
-        Write-Host "Unregistering gallery $gallery..."
+        Write-Output "Unregistering gallery $gallery..."
         Unregister-PSRepository -Name $gallery
     }
 
@@ -142,7 +143,8 @@ try {
 
         # With older base image builds, teams 1.1.6 is already installed 
         if (Get-Module MicrosoftTeams -ListAvailable) {
-            #For some odd reason, Update-Module was create a new module with 
+            # For some odd reason, Update-Module was creating the MicrosoftTeams module twice with different version numbers.
+            # Uninstalling and then installing it again was the only way to keep it as one module. 
             Uninstall-Module MicrosoftTeams -Force
             PowerShellGet\Install-Module -Name MicrosoftTeams @prodAllUsers
         } else {

--- a/linux/powershell/setupPowerShell.ps1
+++ b/linux/powershell/setupPowerShell.ps1
@@ -9,11 +9,6 @@ param(
 
 $ProgressPreference = 'SilentlyContinue' # Suppresses progress, which doesn't render correctly in docker
 
-# The preview version of the PowerShell gallery. We pick up Azure modules from there because they are released to that location shortly before
-# being released to the main gallery. This allows us to build the Cloud Shell image and deploy it to production at the same time that the modules
-# can be downloaded from the main gallery
-$intGallery = 'https://www.poshtestgallery.com/api/v2' 
-
 # PowerShellGallery PROD site
 $prodGallery = 'https://www.powershellgallery.com/api/v2' 
 
@@ -55,6 +50,39 @@ function Install-LibMIFile {
     if ($hash -ne $FileHash) {
         throw "Hash mismatch for $FullPath. Expected: $FileHash Actual:$hash."
     }
+}
+
+# Install Azure and AzureAD (Active Directory) modules
+# This function replaces the old poshtestgallery issue
+function Install-AzAndAzAdModules {
+    echo "Install-AzAndAdModules.."
+    mkdir temp && curl -o az-cmdlets.tar.gz -sSL "https://azpspackage.blob.core.windows.net/release/Az-Cmdlets-7.3.2.35305.tar.gz" 
+    tar -xf az-cmdlets.tar.gz -C temp 
+    rm az-cmdlets.tar.gz
+    cd temp
+
+    curl -o "AzureAD.Standard.Preview.nupkg" -sSL "https://pscloudshellbuild.blob.core.windows.net/azuread-standard-preview/azuread.standard.preview.0.1.599.7.nupkg"
+
+    $SourceLocation = $PSScriptRoot
+    Write-Output "Source Location: $SourceLocation"
+
+    $gallery = [guid]::NewGuid().ToString()
+    Write-Host "Registering temporary repository $gallery with InstallationPolicy Trusted..."
+    Register-PSRepository -Name $gallery -SourceLocation $($pwd.providerPath) -PackageManagementProvider NuGet -InstallationPolicy Trusted
+
+    try {
+        Write-Host "Installing Az..."
+        Install-Module -Name Az -Repository $gallery -Scope AllUsers -AllowClobber -Force
+        Write-Host "Installing AzureAD.Standard.Preview..."
+        Install-Module -Name "AzureAD.Standard.Preview" -Repository $gallery -Scope AllUsers -AllowClobber -Force
+    }
+    finally {
+        Write-Host "Unregistering gallery $gallery..."
+        Unregister-PSRepository -Name $gallery
+    }
+
+    cd ..
+    rm -rf temp
 
 }
 
@@ -85,8 +113,6 @@ try {
 
     # Set up repo as trusted to avoid prompts
     PowerShellGet\Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
-    PowerShellGet\Register-PSRepository -Name intGallery -SourceLocation $intGallery -InstallationPolicy Trusted
-    $intAllUsers = @{Repository = "intGallery"; Scope = "AllUsers"}
     $prodAllUsers = @{Repository = "PSGallery"; Scope = "AllUsers"}
 
     if ($image -eq "Base") {
@@ -101,11 +127,10 @@ try {
         Write-Output "Updating libmi.so"
         Install-LibMIFile
 
-        # Install modules from the PowerShell Test Gallery
-        Write-Output "Installing modules from test gallery"
-        PowerShellGet\Install-Module -Name Az -MaximumVersion $script:dockerfileDataObject.AzMaxVersion @intAllUsers
-        PowerShellGet\Install-Module -Name AzureAD.Standard.Preview -MaximumVersion $script:dockerfileDataObject.AzureADStandardMaxVersion @intAllUsers
-
+        # Installing modules from Azure Powershell and AzureAD
+        Write-Output "Installing modules from Azure Powershell and AzureAD"
+        Install-AzAndAzAdModules
+        
         # Install modules from PSGallery
         Write-Output "Installing modules from production gallery"    
         PowerShellGet\Install-Module -Name AzurePSDrive @prodAllUsers   
@@ -117,7 +142,9 @@ try {
 
         # With older base image builds, teams 1.1.6 is already installed 
         if (Get-Module MicrosoftTeams -ListAvailable) {
-            Update-Module MicrosoftTeams -Force -Scope AllUsers
+            #For some odd reason, Update-Module was create a new module with 
+            Uninstall-Module MicrosoftTeams -Force
+            PowerShellGet\Install-Module -Name MicrosoftTeams @prodAllUsers
         } else {
             PowerShellGet\Install-Module -Name MicrosoftTeams @prodAllUsers     
         }
@@ -154,7 +181,6 @@ try {
 }
 finally {
     # Clean-up the PowerShell Gallery registration settings
-    PowerShellGet\Unregister-PSRepository -Name intGallery -ErrorAction Ignore
     PowerShellGet\Set-PSRepository -Name PSGallery -InstallationPolicy Untrusted -ErrorAction Ignore
     if ($tempDirectory -and (Microsoft.PowerShell.Management\Test-Path $tempDirectory)) {
         Microsoft.PowerShell.Management\Remove-Item $tempDirectory -Force -Recurse -ErrorAction Ignore

--- a/tests/PSinLinuxCloudShellImage.Tests.ps1
+++ b/tests/PSinLinuxCloudShellImage.Tests.ps1
@@ -117,7 +117,6 @@ Describe "PowerShell Modules" {
 
         $module = Get-InstalledModule -Name Az -AllVersions
         $module | Should -Not -BeNullOrEmpty
-        $module.Repository | Should -Be "https://www.poshtestgallery.com/api/v2"
 
         # Verify Az module version
         $module.Version -ge [version]"5.0" | Should -Be $true
@@ -128,14 +127,12 @@ Describe "PowerShell Modules" {
 
         $module = Get-InstalledModule -Name Az.Accounts -AllVersions
         $module | Should -Not -BeNullOrEmpty
-        $module.Repository | Should -Be "https://www.poshtestgallery.com/api/v2"
     }
 
     It "Az.Resources PowerShell Module" {
 
         $module = Get-InstalledModule -Name Az.Resources -AllVersions
         $module | Should -Not -BeNullOrEmpty
-        $module.Repository | Should -Be "https://www.poshtestgallery.com/api/v2"
     }
 
     It "SHiPS PowerShell Module" {

--- a/tests/command_list
+++ b/tests/command_list
@@ -837,6 +837,7 @@ perlivp
 perlthanks
 pg_basebackup
 pgbench
+pg_config
 pg_dump
 pg_dumpall
 pg_isready

--- a/tests/command_list
+++ b/tests/command_list
@@ -837,7 +837,6 @@ perlivp
 perlthanks
 pg_basebackup
 pgbench
-pg_config
 pg_dump
 pg_dumpall
 pg_isready


### PR DESCRIPTION
This PR mitigated the issue regarding the removal of poshtestgallery. 

- The Az Powershell and AzAD Preview library download link has been migrated
- Microsoft Teams will only show up once when you list all the modules through (Get-Module -listavailable)