### PR TITLE
Update url for az powershell

### DIFF
--- a/linux/powershell/setupPowerShell.ps1
+++ b/linux/powershell/setupPowerShell.ps1
@@ -57,7 +57,7 @@ function Install-LibMIFile {
 function Install-AzAndAzAdModules {
     Write-Output "Install-AzAndAdModules.."
     mkdir temp
-    curl -o az-cmdlets.tar.gz -sSL "https://azpspackage.blob.core.windows.net/release/Az-Cmdlets-7.3.2.35305.tar.gz" 
+    curl -o az-cmdlets.tar.gz -sSL "https://azpspackage.blob.core.windows.net/release/Az-Cmdlets-latest.tar.gz" 
     tar -xf az-cmdlets.tar.gz -C temp 
     rm az-cmdlets.tar.gz
     cd temp


### PR DESCRIPTION
Whenever we get a new package from az powershell, we can just rerun the pipeline. We would not need to change the url to get the specific package.