### PR TITLE
Changed the AzureAD.Standard.Preview version

### DIFF
--- a/linux/powershell/setupPowerShell.ps1
+++ b/linux/powershell/setupPowerShell.ps1
@@ -62,7 +62,7 @@ function Install-AzAndAzAdModules {
     rm az-cmdlets.tar.gz
     cd temp
 
-    curl -o "AzureAD.Standard.Preview.nupkg" -sSL "https://pscloudshellbuild.blob.core.windows.net/azuread-standard-preview/azuread.standard.preview.0.1.599.7.nupkg"
+    curl -o "AzureAD.Standard.Preview.nupkg" -sSL "https://pscloudshellbuild.blob.core.windows.net/azuread-standard-preview/azuread.standard.preview.0.0.0.10.nupkg"
 
     $SourceLocation = $PSScriptRoot
     Write-Output "Source Location: $SourceLocation"


### PR DESCRIPTION
Changed the AzureAD.Standard.Preview version to match what was downloaded from the past poshtestgallery. This will also remove the warnings when you enter into powershell on cloudshell.