### PR TITLE
[Test] rename repo name in ACR

### DIFF
--- a/.pipelines/pipeline.user.all_os.all_buildtype.Base.yml
+++ b/.pipelines/pipeline.user.all_os.all_buildtype.Base.yml
@@ -4,7 +4,7 @@ package:
         name: 'Base Docker image for Cloudshell'
         context_folder: '.'
         dockerfile_name: 'linux/base.Dockerfile'
-        repository_name: 'azure/cloudshell'
+        repository_name: 'public/azure-cloudshell'
         export_to_artifact_path: 'images\cloudshell.tar.gz'
         publish_build_tag: 'true'
         publish_unique_tag: 'true'


### PR DESCRIPTION
The repo name (public/azure-cloudshell) [mcr/cloudshell.yml at main · microsoft/mcr (github.com)](https://github.com/microsoft/mcr/blob/main/teams/cloudshell/cloudshell.yml#L10) we current put in the MCR code is not existing in our current ACR. MCR will look for public/azure-cloudshell/ in our registry, if MCR cannot find it, then it won't pick up our new changes. To fix it, there should be an exact same repo name (public/azure-cloudshell) in our private ACR.