### PR TITLE
Use new Hashicorp Releases API

### DIFF
--- a/linux/tools.Dockerfile
+++ b/linux/tools.Dockerfile
@@ -30,7 +30,7 @@ RUN az aks install-cli \
 
 # Download the latest terraform (AMD64), install to global environment.
 RUN gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys B36CBA91A2C0730C435FC280B0B441097685B676 \
-    && TF_VERSION=$(curl -s https://checkpoint-api.hashicorp.com/v1/check/terraform | jq -r -M ".current_version") \
+    && TF_VERSION=$(curl -s https://api.releases.hashicorp.com/v1/releases/terraform/latest | jq -r -M ".version") \
     && wget -nv -O terraform.zip https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_${TF_VERSION}_linux_amd64.zip \
     && wget -nv -O terraform.sha256 https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_${TF_VERSION}_SHA256SUMS \
     && wget -nv -O terraform.sha256.sig https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_${TF_VERSION}_SHA256SUMS.sig \  


### PR DESCRIPTION
Changing the legacy API endpoint URL to the new endpoint that was announced recently:
ref. https://www.hashicorp.com/blog/announcing-the-hashicorp-releases-api

### legacy

```sh
curl -s https://checkpoint-api.hashicorp.com/v1/check/terraform | jq -r .current_version
```
### new

```sh
curl -s https://api.releases.hashicorp.com/v1/releases/terraform/latest | jq -r .version
```

AB#14526453