### PR TITLE
Added SOURCES file to enable source discovery for CBL-D

### DIFF
--- a/SOURCES
+++ b/SOURCES
@@ -1,0 +1,14 @@
+Azure Cloud Shell uses packages from CBL-D:
+- https://packages.microsoft.com/repos/cbl-d/ 
+
+Source for packages in this directory are available at:
+- https://cbldsrc.blob.core.windows.net/quinault/index.html
+- https://cbldsrc.blob.core.windows.net/quinault-universe/index.html
+ 
+Alternately to obtain sources, you may send a check or money order for US $5.00, including the package name, version, and return address to:
+ 
+Source Code Compliance Team
+Microsoft Corporation
+One Microsoft Way
+Redmond, WA 98052
+USA

--- a/linux/base.Dockerfile
+++ b/linux/base.Dockerfile
@@ -17,6 +17,8 @@ FROM sbidprod.azurecr.io/quinault
 
 SHELL ["/bin/bash","-c"] 
 
+# Added to fix CELA requirement to enable users to understand where the source of CBL-D packages come from
+COPY SOURCES .
 COPY linux/aptinstall.sh .
 COPY linux/installMaven.sh .
 


### PR DESCRIPTION
Immediate compliance requirement to add SOURCES into cloud shell image. It is present in the / folder of the image so that customers can see where to get sources from.

Needs a base image release.