### PR TITLE
Added escape characters thus preventing the creation of file =0.2.2 in /opt

### DIFF
--- a/linux/base.Dockerfile
+++ b/linux/base.Dockerfile
@@ -193,7 +193,7 @@ RUN chmod 755 /usr/local/bin/ansible* \
   && pip3 install virtualenv \
   && cd /opt \
   && virtualenv -p python3 ansible \
-  && /bin/bash -c "source ansible/bin/activate && pip3 install ansible && pip3 install pywinrm>=0.2.2 && deactivate" \
+  && /bin/bash -c "source ansible/bin/activate && pip3 install ansible && pip3 install pywinrm\>\=0\.2\.2 && deactivate" \
   && ansible-galaxy collection install azure.azcollection -p /usr/share/ansible/collections
 
 # Install latest version of Istio

--- a/linux/installMaven.sh
+++ b/linux/installMaven.sh
@@ -3,7 +3,7 @@
 # Customized Maven install from Apache mirrors according to best practices
 
 # Download maven from Apache Mirror
-MAVEN_VERSION=3.8.5
+MAVEN_VERSION=3.8.6
 wget https://dlcdn.apache.org/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz -P /opt
 tar xf /opt/apache-maven-$MAVEN_VERSION-bin.tar.gz -C /opt
 ln -s /opt/apache-maven-$MAVEN_VERSION /opt/maven


### PR DESCRIPTION
Properly escaping characters thus preventing the creation of the =0.2.2 file in /opt

![image](https://user-images.githubusercontent.com/6505576/174901472-ae6629ce-9718-42a6-9a1c-4050bca4a0b8.png)

How to reproduce:
- spawn a new cloudshell instance (docker or portal)
- ls -las /opt

Fixing Maven installation by using the latest 3.8.6 instead of 3.8.5 version, apparently 3.8.5 was pulled from the repo: https://dlcdn.apache.org/maven/maven-3/
Release notes for Maven 3.8.6: https://maven.apache.org/docs/3.8.6/release-notes.html

Teams Alias: ajoian