### PR TITLE
update base image pointer for Mariner

### DIFF
--- a/linux/base.Dockerfile
+++ b/linux/base.Dockerfile
@@ -111,9 +111,7 @@ RUN tdnf update -y && bash ./tdnfinstall.sh \
   zsh
 
 # Install Maven
-RUN tdnf -y install mariner-repos-preview
 RUN tdnf update -y && bash ./tdnfinstall.sh maven
-RUN tdnf -y remove mariner-repos-preview
 
 RUN tdnf clean all
 

--- a/linux/tools.Dockerfile
+++ b/linux/tools.Dockerfile
@@ -5,7 +5,7 @@
 
 # To build yourself locally, override this location with a local image tag. See README.md for more detail
 
-ARG IMAGE_LOCATION=cdpxb787066ec88f4e20ae65e42a858c42ca00.azurecr.io/official/azure/cloudshell:1.0.20220720.1.base.mariner_full.d6d09980
+ARG IMAGE_LOCATION=cdpxb787066ec88f4e20ae65e42a858c42ca00.azurecr.io/official/azure/cloudshell:1.0.20220803.1.base.master.585b6c60
 
 # Copy from base build
 FROM ${IMAGE_LOCATION}


### PR DESCRIPTION
The two main things for PR:
- I updated the tools image to point to the newer version of the Mariner base image
- I changed maven to pull from prod instead of the Mariner preview repo