### PR TITLE
Add package postgresql-devel for rdbms-connect extension

### DIFF
--- a/linux/base.Dockerfile
+++ b/linux/base.Dockerfile
@@ -86,6 +86,7 @@ RUN tdnf update -y && bash ./tdnfinstall.sh \
   parallel \
   patch \
   pkg-config \
+  postgresql-devel \
   postgresql-libs \
   postgresql \
   powershell \


### PR DESCRIPTION
`rdbms-connect `extension requires an external library `psycopg2`, and this ir turn requires package `libpq-dev`. The equivalent for that in CBL-Mariner is `postgresql-devel`.