### PR TITLE
Add Azure Developer CLI to CloudShell

### DIFF
--- a/linux/powershell/PSCloudShellUtility/PSCloudShellUtility.psm1
+++ b/linux/powershell/PSCloudShellUtility/PSCloudShellUtility.psm1
@@ -1817,7 +1817,8 @@ function Get-PackageVersion() {
         @{displayname = "Azure CLI"; command = "az"; args = "version "; match = "`"azure-cli`": `"(.+)`""},
         @{displayname = "Kubectl"; command = "kubectl"; args = "version --client=true --short=true"; match = "Client Version: v(.+)"}
         @{displayname = "Terraform"; command = "terraform"; args = "version"; match = "Terraform v(.+)"},
-        @{displayname = "GitHub CLI"; command = "gh"; args = "--version"; match = "gh version (.+) \(.*"}
+        @{displayname = "GitHub CLI"; command = "gh"; args = "--version"; match = "gh version (.+) \(.*"},
+        @{displayname = "Azure Developer CLI"; command = "azd"; args = "version"; match = "azd version \d+\.\d+\.\d+(-[\w\d\.]*)?"}
     )
 
     foreach ($package in $packageVersionDetections) {

--- a/linux/powershell/PSCloudShellUtility/PSCloudShellUtility.psm1
+++ b/linux/powershell/PSCloudShellUtility/PSCloudShellUtility.psm1
@@ -1818,7 +1818,7 @@ function Get-PackageVersion() {
         @{displayname = "Kubectl"; command = "kubectl"; args = "version --client=true --short=true"; match = "Client Version: v(.+)"}
         @{displayname = "Terraform"; command = "terraform"; args = "version"; match = "Terraform v(.+)"},
         @{displayname = "GitHub CLI"; command = "gh"; args = "--version"; match = "gh version (.+) \(.*"},
-        @{displayname = "Azure Developer CLI"; command = "azd"; args = "version"; match = "azd version \d+\.\d+\.\d+(-[\w\d\.]*)?"}
+        @{displayname = "Azure Developer CLI"; command = "azd"; args = "version"; match = "azd version (\d+\.\d+\.\d+(-[\w\d\.]*)?).*"}
     )
 
     foreach ($package in $packageVersionDetections) {

--- a/linux/tools.Dockerfile
+++ b/linux/tools.Dockerfile
@@ -31,6 +31,7 @@ RUN az aks install-cli \
 
 # Install azure-developer-cli (azd)
 ENV AZD_IN_CLOUDSHELL 1
+ENV AZD_SKIP_UPDATE_CHECK 1
 RUN curl -fsSL https://aka.ms/install-azd.sh | bash
 
 RUN mkdir -p /usr/cloudshell

--- a/linux/tools.Dockerfile
+++ b/linux/tools.Dockerfile
@@ -29,6 +29,9 @@ RUN az aks install-cli \
     && chmod +x /usr/local/bin/kubectl \
     && chmod +x /usr/local/bin/kubelogin
 
+# Install azure-developer-cli (azd)
+RUN curl -fsSL https://aka.ms/install-azd.sh | bash
+
 RUN mkdir -p /usr/cloudshell
 WORKDIR /usr/cloudshell
 

--- a/linux/tools.Dockerfile
+++ b/linux/tools.Dockerfile
@@ -30,6 +30,7 @@ RUN az aks install-cli \
     && chmod +x /usr/local/bin/kubelogin
 
 # Install azure-developer-cli (azd)
+ENV AZD_IN_CLOUDSHELL 1
 RUN curl -fsSL https://aka.ms/install-azd.sh | bash
 
 RUN mkdir -p /usr/cloudshell

--- a/tests/command_list
+++ b/tests/command_list
@@ -90,6 +90,7 @@ avcstat
 awk
 az
 azcopy
+azd
 b2sum
 badblocks
 base32


### PR DESCRIPTION
I noticed a couple of failures when running `./test.ps1` locally: 

```
Running tests.
[-] Various programs installed with expected versions.Static Versions 42ms (41ms|1ms)
 Expected strings to be the same, but they were different.
 String lengths are both 7.
 Strings differ at index 4.
 Expected: '16.14.2'
 But was:  '16.16.0'
            ----^
 at $script:pmap["Node.JS"].Version | Should -Be '16.14.2', /tests/PSinLinuxCloudShellImage.Tests.ps1:21
 at <ScriptBlock>, /tests/PSinLinuxCloudShellImage.Tests.ps1:21
[-] Various programs installed with expected versions.Compare bash commands to baseline 59ms (58ms|1ms)
 Expected strings to be the same, because Commands 'aserver,fc-cache,fc-cat,fc-conflist,fc-list,fc-match,fc-pattern,fc-query,fc-scan,fc-validate,pngfix,png-fix-itxt' should be installed on the path but were not found. No commands should have been removed unexpectedly. If one really should be deleted, remove it from command_list, but they were different.
 Expected length: 0
 Actual length:   112
 Strings differ at index 0.
 Expected: ''
 But was:  'aserver,fc-cache,fc-cat,fc-conflist,fc-list,fc-match,fc-patt...'
            ^
 at $missing | Should -Be "" -Because "Commands '$missing' should be installed on the path but were not found. No commands should have been removed unexpectedly. If one really should be deleted, remove it from command_list", /tests/PSinLinuxCloudShellImage.Tests.ps1:68
 at <ScriptBlock>, /tests/PSinLinuxCloudShellImage.Tests.ps1:68
Tests completed in 47.24s
Tests Passed: 34, Failed: 2, Skipped: 0 NotRun: 0
```

Looks like more than a few commands are categorized as "missing" and the expected version of NodeJS is out of date. 

Also, I didn't see an error when I left `azd` out of `command_list`... ~Digging into that more deeply now.~ This appears to be caused by [multiple `Should` assertions in a single `It` block](https://github.com/Azure/CloudShell/blob/master/tests/PSinLinuxCloudShellImage.Tests.ps1#L67-L71) where the first `Should` fails and the second `Should` does not run. 