### PR TITLE
Enable Az.Tools.Predictor by default

### DIFF
--- a/linux/powershell/setupPowerShell.ps1
+++ b/linux/powershell/setupPowerShell.ps1
@@ -142,6 +142,7 @@ try {
         PowerShellGet\Install-Module -Name ExchangeOnlineManagement -RequiredVersion 2.0.5 -Force
         PowerShellGet\Install-Module -Name Microsoft.PowerShell.SecretManagement @prodAllUsers
         PowerShellGet\Install-Module -Name Microsoft.PowerShell.SecretStore @prodAllUsers
+        PowerShellGet\Install-Module -Name Az.Accounts -Repository PSGallery
 
         # With older base image builds, teams 1.1.6 is already installed 
         if (Get-Module MicrosoftTeams -ListAvailable) {
@@ -172,7 +173,9 @@ try {
         Write-Output "Installing powershell profile to $($PROFILE.AllUsersAllHosts)"
         Microsoft.PowerShell.Management\Copy-Item -Path $psStartupScript -Destination $PROFILE.AllUsersAllHosts -Verbose
         Write-Output "Installed powershell profile."
-        
+        Write-Output "Updating PowerShell profile"
+        Add-Content -path $Profile -value "Set-PSReadLineOption -Colors @{ InLinePrediction = '#2F7004'}","Import-Module AZ.Tools.Predictor"
+
         # Update PowerShell Core help files in the image, ensure any errors that result in help not being updated does not interfere with the build process
         # We want the image to have latest help files when shipped.
         Write-Output "Updating help files."


### PR DESCRIPTION
This pull request adds:

- New version of Az.Accounts (need for az.tools.predictor)
- Adds lines to profile (if existing "add"; if not, create profile)

```PowerShell
Set-PSReadLineOption -Colors @{ InLinePrediction = '#2F7004'}
Import-Module AZ.Tools.Predictor
```