### PR TITLE
Modify nodejs package version in test

### DIFF
--- a/tests/PSinLinuxCloudShellImage.Tests.ps1
+++ b/tests/PSinLinuxCloudShellImage.Tests.ps1
@@ -18,9 +18,8 @@ Describe "Various programs installed with expected versions" {
 
     It "Static Versions" {
         # These programs are installed explicitly with specific versions
-        $script:pmap["Node.JS"].Version | Should -Be '16.16.0'
+        $script:pmap["Node.JS"].Version | Should -Be '16.17.1'
         $script:pmap["PowerShell"].Version | Should -BeLike '7.2*'
-        $script:pmap["Helm"].Version | Should -BeLike '3.9.*'       
     }
 
     It "Some Versions Installed" {


### PR DESCRIPTION
Modify the test for nodejs package version. Mariner upgraded their nodejs package. Therefore, the test in Cloudshell was failing. 