### PR TITLE
Add redis including redis-cli

### DIFF
--- a/linux/base.Dockerfile
+++ b/linux/base.Dockerfile
@@ -134,7 +134,8 @@ RUN bash ./tdnfinstall.sh \
   screen \
   postgresql-devel \
   terraform \
-  gh
+  gh \
+  redis
 
 # Install azure-functions-core-tools
 RUN wget -nv -O Azure.Functions.Cli.linux-x64.4.0.3971.zip https://github.com/Azure/azure-functions-core-tools/releases/download/4.0.3971/Azure.Functions.Cli.linux-x64.4.0.3971.zip \

--- a/linux/tools.Dockerfile
+++ b/linux/tools.Dockerfile
@@ -33,6 +33,7 @@ RUN az aks install-cli \
 RUN bash ./tdnfinstall.sh postgresql-devel
 RUN bash ./tdnfinstall.sh terraform
 RUN bash ./tdnfinstall.sh gh
+RUN bash ./tdnfinstall.sh redis
 
 RUN mkdir -p /usr/cloudshell
 WORKDIR /usr/cloudshell

--- a/tests/command_list
+++ b/tests/command_list
@@ -1014,6 +1014,7 @@ readonly
 readprofile
 realpath
 reboot
+redis-cli
 refer
 register-python-argcomplete
 reindexdb


### PR DESCRIPTION
Resolves #275.

Add `redis` package to base and tools. This brings in [redis-cli](https://redis.io/docs/manual/cli/) for managing [Azure Cache for Redis](https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/cache-how-to-redis-cli-tool). Mariner did not include `redis-tools`.