### PR TITLE
Update packages

### DIFF
--- a/linux/base.Dockerfile
+++ b/linux/base.Dockerfile
@@ -28,7 +28,6 @@ RUN bash ./tdnfinstall.sh \
   nodejs
 
 ENV NPM_CONFIG_LOGLEVEL warn
-ENV NODE_VERSION 16.17.1
 ENV NODE_ENV production
 ENV NODE_OPTIONS=--tls-cipher-list='ECDHE-RSA-AES128-GCM-SHA256:!RC4'
 
@@ -50,8 +49,8 @@ RUN bash ./tdnfinstall.sh \
   curl \
   bind-utils \
   dos2unix \
-  dotnet-runtime-6.0 \
-  dotnet-sdk-6.0 \
+  dotnet-runtime-7.0 \
+  dotnet-sdk-7.0 \
   e2fsprogs \
   emacs \
   gawk \
@@ -138,14 +137,14 @@ RUN bash ./tdnfinstall.sh \
   redis
 
 # Install azure-functions-core-tools
-RUN wget -nv -O Azure.Functions.Cli.linux-x64.4.0.3971.zip https://github.com/Azure/azure-functions-core-tools/releases/download/4.0.3971/Azure.Functions.Cli.linux-x64.4.0.3971.zip \
-  && unzip -d azure-functions-cli Azure.Functions.Cli.linux-x64.4.0.3971.zip \
+RUN wget -nv -O Azure.Functions.Cli.zip `curl -fSsL https://api.github.com/repos/Azure/azure-functions-core-tools/releases/latest | grep "url.*linux-x64" | grep -v "sha2" | cut -d '"' -f4` \
+  && unzip -d azure-functions-cli Azure.Functions.Cli.zip \
   && chmod +x azure-functions-cli/func \
   && chmod +x azure-functions-cli/gozip \
-  && mv azure-functions-cli /opt \
+  && mv -v azure-functions-cli /opt \
   && ln -sf /opt/azure-functions-cli/func /usr/bin/func \
   && ln -sf /opt/azure-functions-cli/gozip /usr/bin/gozip \
-  && rm -r Azure.Functions.Cli.linux-x64.4.0.3971.zip
+  && rm -r Azure.Functions.Cli.zip
 
 
 # Setup locale to en_US.utf8
@@ -208,10 +207,10 @@ ENV GOROOT="/usr/lib/golang"
 ENV PATH="$PATH:$GOROOT/bin:/opt/mssql-tools18/bin"
 
 
-RUN gem install bundler --version 1.16.4 --force \
-  && gem install rake --version 12.3.0 --no-document --force \
-  && gem install colorize --version 0.8.1 --no-document --force \
-  && gem install rspec --version 3.7.0 --no-document --force
+RUN gem install bundler --force \
+  && gem install rake --no-document --force \
+  && gem install colorize --no-document --force \
+  && gem install rspec --no-document --force
 
 ENV GEM_HOME=~/bundle
 ENV BUNDLE_PATH=~/bundle

--- a/linux/base.Dockerfile
+++ b/linux/base.Dockerfile
@@ -221,9 +221,6 @@ ENV POWERSHELL_DISTRIBUTION_CHANNEL CloudShell
 # don't tell users to upgrade, they can't
 ENV POWERSHELL_UPDATECHECK Off
 
-# Install Azure draft
-RUN curl -fsSL https://raw.githubusercontent.com/Azure/draft/main/scripts/install.sh | bash
-
 # Install Yeoman Generator and predefined templates
 RUN npm install -g yo \
   && npm install -g generator-az-terra-module

--- a/linux/powershell/PSCloudShellUtility/PSCloudShellUtility.psm1
+++ b/linux/powershell/PSCloudShellUtility/PSCloudShellUtility.psm1
@@ -1813,7 +1813,6 @@ function Get-PackageVersion() {
         @{displayname = "DC/OS CLI"; command = "dcos"; args = "--version"; match = "dcoscli.version=(.*)"},
         @{displayname = "Ripgrep"; command = "rg"; args = "--help | head"; match = "ripgrep ([\d\.]+)$"},
         @{displayname = "Helm"; command = "helm"; args = "version --short"; match = "v(.+)"},
-        @{displayname = "Draft"; command = "draft"; args = "version"; match = "version:  (.+)"},
         @{displayname = "AZCopy"; command = "azcopy"; args = "--version"; match = "azcopy version (.+)"},
         @{displayname = "Azure CLI"; command = "az"; args = "version "; match = "`"azure-cli`": `"(.+)`""},
         @{displayname = "Kubectl"; command = "kubectl"; args = "version --client=true --short=true"; match = "Client Version: v(.+)"}

--- a/linux/tools.Dockerfile
+++ b/linux/tools.Dockerfile
@@ -13,10 +13,6 @@ RUN tdnf clean all
 RUN tdnf repolist --refresh
 RUN ACCEPT_EULA=Y tdnf update -y
 
-RUN tdnf remove -y msodbcsql17 mssql-tools
-RUN ACCEPT_EULA=Y tdnf install -y msodbcsql18 mssql-tools18
-ENV PATH $PATH:/opt/mssql-tools18/bin
-
 # Install latest Azure CLI package. CLI team drops latest (pre-release) package here prior to public release
 # We don't support using this location elsewhere - it may be removed or updated without notice
 RUN wget https://azurecliprod.blob.core.windows.net/cloudshell-release/azure-cli-latest-mariner2.0.rpm \
@@ -41,11 +37,6 @@ RUN curl -LO https://github.com/sozercan/kubectl-ai/releases/latest/download/kub
     tar xzf kubectl-ai_linux_amd64.tar.gz && \
     mv kubectl-ai /usr/local/bin/kubectl-ai && \
     rm -rf kubectl-ai_linux_amd64.tar.gz kubectl-ai_checksums.txt
-
-# Remove after base image gets updated
-RUN bash ./tdnfinstall.sh postgresql-devel
-RUN bash ./tdnfinstall.sh terraform
-RUN bash ./tdnfinstall.sh gh
 
 RUN mkdir -p /usr/cloudshell
 WORKDIR /usr/cloudshell

--- a/linux/tools.Dockerfile
+++ b/linux/tools.Dockerfile
@@ -29,15 +29,6 @@ RUN az aks install-cli \
     && chmod +x /usr/local/bin/kubectl \
     && chmod +x /usr/local/bin/kubelogin
 
-# Install kubectl-ai
-RUN curl -LO https://github.com/sozercan/kubectl-ai/releases/latest/download/kubectl-ai_linux_amd64.tar.gz && \
-    curl -LO https://github.com/sozercan/kubectl-ai/releases/latest/download/kubectl-ai_checksums.txt && \
-    CHECKSUM=$(grep kubectl-ai_linux_amd64.tar.gz kubectl-ai_checksums.txt | awk '{print $1}') && \
-    echo "$CHECKSUM  kubectl-ai_linux_amd64.tar.gz" | sha256sum -c - && \
-    tar xzf kubectl-ai_linux_amd64.tar.gz && \
-    mv kubectl-ai /usr/local/bin/kubectl-ai && \
-    rm -rf kubectl-ai_linux_amd64.tar.gz kubectl-ai_checksums.txt
-
 RUN mkdir -p /usr/cloudshell
 WORKDIR /usr/cloudshell
 

--- a/tests/command_list
+++ b/tests/command_list
@@ -262,7 +262,6 @@ domainname
 done
 dos2unix
 dotnet
-draft
 dropdb
 dropuser
 du
@@ -636,7 +635,6 @@ ksba-config
 kswitch
 ktutil
 kubectl
-kubectl-ai
 kubelogin
 kvno
 last


### PR DESCRIPTION
Things that are done in this PR:
- update dotnet version from 6 to 7
- get latest version of azure functions cli
- get latest versions of all the packages that gem installs (ex. bundler)
- remove kubectl-ai
- remove Azure draft
- remove duplicate installs in the tools image

Tested K8, ACI, and VNet scenarios. 