### PR TITLE
Update shellghazdosync.yml

### DIFF
--- a/.github/workflows/shellghazdosync.yml
+++ b/.github/workflows/shellghazdosync.yml
@@ -3,7 +3,7 @@ name: Sync GitHub issue to Azure DevOps work item
 on:
   issues:
     types:
-      [opened, edited, deleted, closed, reopened, labeled, unlabeled, assigned]
+      [opened]
 
 jobs:
   alert:


### PR DESCRIPTION
Only add github items to the backlog when they are created. If they are also added on other events, we end up with a whole bunch of duplicates in the Azure DevOps backlog.