### PR TITLE
Update shellgnazdoprsync.yml

### DIFF
--- a/.github/workflows/shellgnazdoprsync.yml
+++ b/.github/workflows/shellgnazdoprsync.yml
@@ -2,7 +2,7 @@ name: Sync Pull Request to Azure Boards
 
 on:
   pull_request_target:
-    types: [opened, edited, closed]
+    types: [opened]
     branches:
       - master
 


### PR DESCRIPTION
Only create a new AzDo item when a GitHub PR is opened, not on other events. This is to avoid spamming the AzDo backlog with new items.