### PR TITLE
Use $HOME instead of ~ in PATH env variable

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -37,7 +37,7 @@ jobs:
 
       # Run the test cases
       - name: Run the test cases
-        run: docker run --volume $(pwd)/tests:/tests tools_cloudshell /bin/bash /tests/test.sh
+        run: docker run -i --volume $(pwd)/tests:/tests tools_cloudshell /bin/bash /tests/test.sh
 
       # Show Docker image size
       - name: find the pull request id

--- a/linux/bash/bashrc
+++ b/linux/bash/bashrc
@@ -1,0 +1,11 @@
+# Start: Define custom environment variables
+
+# Add dotnet tools to PATH so users can install a tool using dotnet tools and
+# can execute that command from any directory
+export PATH=$HOME/.dotnet/tools:$PATH
+
+# Add user's home directories to PATH at the front so they can install tools
+# which override defaults
+export PATH=$HOME/.local/bin:$HOME/bin:$PATH
+
+# End: Define custom environment variables

--- a/linux/tools.Dockerfile
+++ b/linux/tools.Dockerfile
@@ -66,10 +66,10 @@ RUN rm -f ./linux/Dockerfile && rm -f /bin/su
 RUN ln -s /usr/bin/python3 /usr/bin/python
 RUN ln -s /usr/bin/node /usr/bin/nodejs
 
-# Add user's home directories to PATH at the front so they can install tools which
-# override defaults
-# Add dotnet tools to PATH so users can install a tool using dotnet tools and can execute that command from any directory
-ENV PATH ~/.local/bin:~/bin:~/.dotnet/tools:$PATH
+# Add custom environment variables to /etc/skel/.bashrc so they will be
+# available to users any time they open a new shell.
+COPY ./linux/bash/bashrc linux/bashrc
+RUN cat linux/bashrc >> /etc/skel/.bashrc && rm linux/bashrc
 
 # Set AZUREPS_HOST_ENVIRONMENT
 ENV AZUREPS_HOST_ENVIRONMENT cloud-shell/1.0

--- a/tests/PSinLinuxCloudShellImage.Tests.ps1
+++ b/tests/PSinLinuxCloudShellImage.Tests.ps1
@@ -74,8 +74,8 @@ Describe "Various programs installed with expected versions" {
 
     It "has local paths in `$PATH" {
         $paths = ($env:PATH).split(":")
-        $paths | Should -Contain "~/bin"
-        $paths | Should -Contain "~/.local/bin"
+        $paths | Should -Contain "$HOME/bin"
+        $paths | Should -Contain "$HOME/.local/bin"
     }
 
     It "Ansible pwsh has modules" {

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -19,5 +19,9 @@ pwsh /tests/root-tests.ps1
 
 pwsh -c "Install-Module Pester -Force -Scope AllUsers"
 
+# Run tests as csuser with an interactive shell to verify the configuration in
+# the same environment this imange will be used in. Otherwise, the .bashrc won't
+# be sourced and the bash configuration (e.g., environment variables) won't be
+# set during the tests.
 echo "running tests as csuser"
-runuser -u csuser pwsh /tests/test.ps1
+runuser -u csuser -- /bin/bash -i -c 'pwsh /tests/test.ps1'


### PR DESCRIPTION
Hi folks,

I was running some experiments with the [InnovationEngine](https://github.com/Azure/InnovationEngine/) project, which leverage the [CloudShell](https://ms.portal.azure.com/#cloudshell/) to execute the documentation, and I faced a problem with the the `PATH` env variable. In particular, I noticed some paths within `PATH` are using `~` instead of `$HOME` and some tools don't parse `~` thus they aren't able to execute the binaries located on those paths. An example of the tools impacted is `kubectl`. [Here](https://github.com/kubernetes/kubernetes/issues/7339) the issue reported upstream. The solution is to use `$HOME` instead of `~`, which shouldn't have any impact on tools already working with `~`. I tried in other online shells and systems I could try, and none of them are using `~` within `PATH`.

Thanks