### PR TITLE
Fix  Azure Ansible azcollection installation issue

### DIFF
--- a/linux/base.Dockerfile
+++ b/linux/base.Dockerfile
@@ -201,7 +201,7 @@ RUN chmod 755 /usr/local/bin/ansible* \
   && cd /opt \
   && virtualenv -p python3 ansible \
   && /bin/bash -c "source ansible/bin/activate && pip3 install ansible && pip3 install pywinrm\>\=0\.2\.2 && deactivate" \
-  && ansible-galaxy collection install azure.azcollection -p /usr/share/ansible/collections
+  && ansible-galaxy collection install azure.azcollection --force -p /usr/share/ansible/collections
 
 # Install latest version of Istio
 ENV ISTIO_ROOT /usr/local/istio-latest


### PR DESCRIPTION
Since the Python package folder have included the azcollection, the Ansible azcollection installation command will be ignored. But the default Ansible collection location does not include the python package path which result in error: `ERROR! couldn't resolve module/action`, update the azcollection installation command to force azcollection to be installed to the default Ansible collection path.