### PR TITLE
Add vim-extra package

### DIFF
--- a/linux/base.Dockerfile
+++ b/linux/base.Dockerfile
@@ -101,6 +101,7 @@ RUN bash ./tdnfinstall.sh \
   unzip \
   util-linux \
   vim \
+  vim-extra \
   wget \
   which \
   zip \


### PR DESCRIPTION
The vim-extra package adds various features that allow vim to be used more productively, such as [plugins](https://github.com/vim/vim/tree/master/runtime/plugin) and [syntax](https://github.com/vim/vim/tree/master/runtime/syntax) files. For comparison, the GCP, IBM, Oracle, and AWS Cloud Shells all have an equivalent package preinstalled.

Fixes #245 

Has an install size of ~35M:
```
root [ / ]# yum info --installed vim-extra                              
Loaded plugin: tdnfrepogpgcheck                                         
Name          : vim-extra                                               
Arch          : x86_64                                                  
Epoch         : 0                                                       
Version       : 9.0.2121                                                
Release       : 2.cm2                                                   
Install Size  :  35.34M (37056166)                                      
Repo          : @System                                                 
Summary       : Extra files for Vim text editor                         
URL           : https://www.vim.org                                     
License       : Vim                                                     
Description   : The vim extra package contains a extra files for powerful text editor.                                                          
                                                                        
                                                                        
Total Size:  35.34M (37056166)
```