### PR TITLE
Revert to previous base version

### DIFF
--- a/linux/tools.Dockerfile
+++ b/linux/tools.Dockerfile
@@ -4,7 +4,7 @@
 
 # To build yourself locally, override this location with a local image tag. See README.md for more detail
 
-ARG IMAGE_LOCATION=cdpxb787066ec88f4e20ae65e42a858c42ca00.azurecr.io/official/cloudshell:base.master.b9dd9968.20240229.1
+ARG IMAGE_LOCATION=cdpxb787066ec88f4e20ae65e42a858c42ca00.azurecr.io/official/cloudshell:base.master.624adefe.20231129.1
 
 # Copy from base build
 FROM ${IMAGE_LOCATION}


### PR DESCRIPTION
The base image version in the tools dockerfile is not available in the cache, reverting to the previously cached one.