### PR TITLE
base.Dockerfile: Update virtualenv dependencies

### DIFF
--- a/linux/base.Dockerfile
+++ b/linux/base.Dockerfile
@@ -174,7 +174,7 @@ RUN chmod 755 /usr/local/bin/ansible* \
   && pip3 install virtualenv \
   && cd /opt \
   && virtualenv -p python3 ansible \
-  && /bin/bash -c "source ansible/bin/activate && pip3 install ansible && pip3 install pywinrm\>\=0\.2\.2 && deactivate" \
+  && /bin/bash -c "source ansible/bin/activate && pip3 list --outdated --format=freeze | cut -d '=' -f1 | xargs -n1 pip3 install -U && pip3 install ansible && pip3 install pywinrm\>\=0\.2\.2 && deactivate" \
   && ansible-galaxy collection install azure.azcollection --force -p /usr/share/ansible/collections
 
 # Install latest version of Istio


### PR DESCRIPTION
It is possible that the virtualenv installed by the base image is old hence it also generates an environment with older tools. So before installing anything, we should update the virtualenv dependencies.