### PR TITLE
coalesce-tdnf-install: Use only one RUN command

### DIFF
--- a/linux/base.Dockerfile
+++ b/linux/base.Dockerfile
@@ -21,17 +21,10 @@ RUN tdnf update -y --refresh
 COPY linux/tdnfinstall.sh .
 
 RUN bash ./tdnfinstall.sh \
-  mariner-repos-extended
-
-# Install nodejs
-RUN bash ./tdnfinstall.sh \
-  nodejs18
-
-ENV NPM_CONFIG_LOGLEVEL warn
-ENV NODE_ENV production
-ENV NODE_OPTIONS=--tls-cipher-list='ECDHE-RSA-AES128-GCM-SHA256:!RC4'
-
-RUN bash ./tdnfinstall.sh \
+  mariner-repos-extended && \
+  tdnf repolist --refresh && \
+  bash ./tdnfinstall.sh \
+  nodejs18 \
   curl \
   xz \
   git \
@@ -135,7 +128,13 @@ RUN bash ./tdnfinstall.sh \
   gh \
   redis \
   cpio \
-  gettext
+  gettext && \
+  tdnf clean all && \
+  rm -rf /var/cache/tdnf/*
+
+ENV NPM_CONFIG_LOGLEVEL warn
+ENV NODE_ENV production
+ENV NODE_OPTIONS=--tls-cipher-list='ECDHE-RSA-AES128-GCM-SHA256:!RC4'
 
 # Get latest version of Terraform.
 # Customers require the latest version of Terraform.

--- a/linux/tools.Dockerfile
+++ b/linux/tools.Dockerfile
@@ -9,15 +9,16 @@ ARG IMAGE_LOCATION=cdpxb787066ec88f4e20ae65e42a858c42ca00.azurecr.io/official/cl
 # Copy from base build
 FROM ${IMAGE_LOCATION}
 
-RUN tdnf clean all
-RUN tdnf repolist --refresh
-RUN ACCEPT_EULA=Y tdnf update -y
-
-# Install latest Azure CLI package. CLI team drops latest (pre-release) package here prior to public release
-# We don't support using this location elsewhere - it may be removed or updated without notice
-RUN wget https://azurecliprod.blob.core.windows.net/cloudshell-release/azure-cli-latest-mariner2.0.rpm \
+RUN tdnf clean all && \
+    tdnf repolist --refresh && \
+    ACCEPT_EULA=Y tdnf update -y && \
+    # Install latest Azure CLI package. CLI team drops latest (pre-release) package here prior to public release
+    # We don't support using this location elsewhere - it may be removed or updated without notice
+    wget https://azurecliprod.blob.core.windows.net/cloudshell-release/azure-cli-latest-mariner2.0.rpm \
     && tdnf install -y ./azure-cli-latest-mariner2.0.rpm \
-    && rm azure-cli-latest-mariner2.0.rpm
+    && rm azure-cli-latest-mariner2.0.rpm && \
+    tdnf clean all && \
+    rm -rf /var/cache/tdnf/*
 
 # Install any Azure CLI extensions that should be included by default.
 RUN az extension add --system --name ai-examples -y \


### PR DESCRIPTION
Instead of scattering the tdnf installs across various run commands and leaving behind a cache of tdnf metadata, coallesce all the tdnf installs into a single RUN command. This will ensure that the cache is not left behind and the image size is reduced.