### PR TITLE
base-image: Remove blobxfer

### DIFF
--- a/linux/base.Dockerfile
+++ b/linux/base.Dockerfile
@@ -168,14 +168,6 @@ ENV LANG="en_US.utf8"
 RUN pip3 install --upgrade sfctl \
   && pip3 install --upgrade mssql-scripter
 
-# Install Blobxfer and Batch-Shipyard in isolated virtualenvs
-COPY ./linux/blobxfer /usr/local/bin
-RUN chmod 755 /usr/local/bin/blobxfer \
-  && pip3 install virtualenv \
-  && cd /opt \
-  && virtualenv -p python3 blobxfer \
-  && /bin/bash -c "source blobxfer/bin/activate && pip3 install blobxfer && deactivate"
-
 # # BEGIN: Install Ansible in isolated Virtual Environment
 COPY ./linux/ansible/ansible*  /usr/local/bin/
 RUN chmod 755 /usr/local/bin/ansible* \

--- a/linux/blobxfer
+++ b/linux/blobxfer
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-set -e
-
-source /opt/blobxfer/bin/activate
-blobxfer $*
-deactivate

--- a/linux/powershell/PSCloudShellUtility/PSCloudShellUtility.psm1
+++ b/linux/powershell/PSCloudShellUtility/PSCloudShellUtility.psm1
@@ -1803,7 +1803,6 @@ function Get-PackageVersion() {
     $packageVersionDetections = @(
         @{displayname = "Node.JS"; command = "node"; args = "--version"; match = "v(.*)"},
         @{displayname = "Cloud Foundry CLI"; command = "cf"; args = "-v"; match = "cf version (.*)"},
-        @{displayname = "Blobxfer"; command = "blobxfer"; args = "--version"; match = "blobxfer, version (.*)"},
         @{displayname = "Ansible"; command = "ansible"; args = "--version"; match = "ansible \[core ([\d\.]+)\]"},
         @{displayname = "Istio"; command = "istioctl"; args = "version -s --remote=false"; match = "(.+)"},
         @{displayname = "Go"; command = "go"; args = "version"; match = "go version go(\S+) .*"},

--- a/tests/command_list
+++ b/tests/command_list
@@ -109,7 +109,6 @@ bison
 blkdiscard
 blkid
 blkzone
-blobxfer
 blockdev
 break
 bridge


### PR DESCRIPTION
This commit removes blobxfer from the base image, since this project is no longer maintained in the upstream.

Fixes #407 