### PR TITLE
base-image: Remove azure-functions-cli

### DIFF
--- a/linux/base.Dockerfile
+++ b/linux/base.Dockerfile
@@ -148,17 +148,6 @@ RUN TF_VERSION=$(curl -s https://checkpoint-api.hashicorp.com/v1/check/terraform
   && rm -f terraform.zip terraform.sha256 \
   && unset TF_VERSION
 
-# Install azure-functions-core-tools
-RUN wget -nv -O Azure.Functions.Cli.zip `curl -fSsL https://api.github.com/repos/Azure/azure-functions-core-tools/releases/latest | grep "url.*linux-x64" | grep -v "sha2" | cut -d '"' -f4` \
-  && unzip -d azure-functions-cli Azure.Functions.Cli.zip \
-  && chmod +x azure-functions-cli/func \
-  && chmod +x azure-functions-cli/gozip \
-  && mv -v azure-functions-cli /opt \
-  && ln -sf /opt/azure-functions-cli/func /usr/bin/func \
-  && ln -sf /opt/azure-functions-cli/gozip /usr/bin/gozip \
-  && rm -r Azure.Functions.Cli.zip
-
-
 # Setup locale to en_US.utf8
 RUN echo en_US UTF-8 >> /etc/locale.conf && locale-gen.sh
 ENV LANG="en_US.utf8"

--- a/tests/command_list
+++ b/tests/command_list
@@ -381,7 +381,6 @@ fsck.ext4
 fsck.minix
 fsfreeze
 fstrim
-func
 function
 funzip
 fuser
@@ -449,7 +448,6 @@ gnutls-cli-debug
 gnutls-serv
 go
 gofmt
-gozip
 gpasswd
 gperl
 gpg


### PR DESCRIPTION
A user can still install these tools using npm.