### PR TITLE
command_list: Remove docker-proxy from test list

### DIFF
--- a/tests/command_list
+++ b/tests/command_list
@@ -260,7 +260,6 @@ do
 docker
 dockerd
 docker-init
-docker-proxy
 domainname
 done
 dos2unix


### PR DESCRIPTION
moby-engine package stopped shipping docker-proxy binary from version `24.0.9`. Hence remove the docker-proxy binary from the test list.

---

## Testing 

Start a mariner container:

```bash
docker run -it mcr.microsoft.com/cbl-mariner/base/core:2.0 bash
```

Now export one of the following version:

```bash
export MOBY_VERSION="20.10.27-4"
# OR
export MOBY_VERSION="24.0.9-1"
```

And then install the docker engine to test if they ship the `docker-proxy` binary:

```bash
curl -LO https://packages.microsoft.com/cbl-mariner/2.0/prod/base/x86_64/Packages/m/moby-engine-${MOBY_VERSION}.cm2.x86_64.rpm
tdnf install -y ./moby-engine-${MOBY_VERSION}.cm2.x86_64.rpm
command -v docker-proxy || echo "There is no docker-proxy"
```