### PR TITLE
base-image: Remove the pip & virtualenv cache

### DIFF
--- a/linux/base.Dockerfile
+++ b/linux/base.Dockerfile
@@ -154,7 +154,8 @@ ENV LANG="en_US.utf8"
 # Update pip and Install Service Fabric CLI
 # Install mssql-scripter
 RUN pip3 install --upgrade sfctl \
-  && pip3 install --upgrade mssql-scripter
+  && pip3 install --upgrade mssql-scripter \
+  && rm -rf ~/.cache/pip/
 
 # # BEGIN: Install Ansible in isolated Virtual Environment
 COPY ./linux/ansible/ansible*  /usr/local/bin/
@@ -162,6 +163,8 @@ RUN chmod 755 /usr/local/bin/ansible* \
   && cd /opt \
   && virtualenv -p python3 ansible \
   && /bin/bash -c "source ansible/bin/activate && pip3 list --outdated --format=freeze | cut -d '=' -f1 | xargs -n1 pip3 install -U && pip3 install ansible && pip3 install pywinrm\>\=0\.2\.2 && deactivate" \
+  && rm -rf ~/.local/share/virtualenv/ \
+  && rm -rf ~/.cache/pip/ \
   && ansible-galaxy collection install azure.azcollection --force -p /usr/share/ansible/collections
 
 # Install latest version of Istio


### PR DESCRIPTION
Pip stores cache in `~/.cache/pip/` and when the virtualenv is invoked there is also a cache created in `~/.local/share/virtualenv/`. This cache is not required for the base image and can be removed to reduce the size of the image. Also if this cache has older / vulnerable software they are flagged by the security scanners.