### PR TITLE
base & tools: Consolidate PowerShell setup

### DIFF
--- a/linux/base.Dockerfile
+++ b/linux/base.Dockerfile
@@ -184,12 +184,3 @@ RUN gem install bundler --no-document --clear-sources --force \
 ENV GEM_HOME=~/bundle
 ENV BUNDLE_PATH=~/bundle
 ENV PATH=$PATH:$GEM_HOME/bin:$BUNDLE_PATH/gems/bin
-
-# PowerShell telemetry
-ENV POWERSHELL_DISTRIBUTION_CHANNEL CloudShell
-# don't tell users to upgrade, they can't
-ENV POWERSHELL_UPDATECHECK Off
-
-# Copy and run script to Install powershell modules
-COPY ./linux/powershell/ powershell
-RUN /usr/bin/pwsh -File ./powershell/setupPowerShell.ps1 -image Base && rm -rf ./powershell


### PR DESCRIPTION
Move the powershell module installation from the
base Dockerfile to the tools Dockerfile into one
RUN command. This will help in reducing the number of layers in the Docker image, thus also reducing
the size of the image.