### PR TITLE
tools-image: Fix the azure ansible collection installation

### DIFF
--- a/linux/tools.Dockerfile
+++ b/linux/tools.Dockerfile
@@ -55,8 +55,8 @@ RUN curl -Lo bicep https://github.com/Azure/bicep/releases/latest/download/bicep
 
 # Temp: fix ansible modules. Proper fix is to update base layer to use regular python for Ansible.
 RUN mkdir -p /usr/share/ansible/collections/ansible_collections/azure/azcollection/ \
-    && wget -nv -q -O /usr/share/ansible/collections/ansible_collections/azure/azcollection/requirements-azure.txt https://raw.githubusercontent.com/ansible-collections/azure/dev/requirements-azure.txt \
-    && /opt/ansible/bin/python -m pip install -r /usr/share/ansible/collections/ansible_collections/azure/azcollection/requirements-azure.txt
+    && wget -nv -q -O /usr/share/ansible/collections/ansible_collections/azure/azcollection/requirements.txt https://raw.githubusercontent.com/ansible-collections/azure/dev/requirements.txt \
+    && /opt/ansible/bin/python -m pip install -r /usr/share/ansible/collections/ansible_collections/azure/azcollection/requirements.txt
 
 # Copy and run script to Install powershell modules and setup Powershell machine profile
 COPY ./linux/powershell/PSCloudShellUtility/ /usr/local/share/powershell/Modules/PSCloudShellUtility/


### PR DESCRIPTION
The upstream has moved the ansible collections `requirements-azure.txt` to `requirements.txt` file in the PR: https://github.com/ansible-collections/azure/pull/1552. So we need to update the `requirements-azure.txt` to `requirements.txt` in the `tools.Dockerfile` to fix the installation of the azure ansible collection.