### PR TITLE
base: Remove dockerd from the base image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ bld/
 
 # test results
 tests/installed_commands
+tests/testResults.xml
 
 # Visual Studio 2015/2017 cache/options directory
 .vs/
@@ -224,7 +225,7 @@ ClientBin/
 *.publishsettings
 orleans.codegen.cs
 
-# Including strong name files can present a security risk 
+# Including strong name files can present a security risk
 # (https://github.com/github/gitignore/pull/2483#issue-259490424)
 #*.snk
 
@@ -320,7 +321,7 @@ __pycache__/
 # OpenCover UI analysis results
 OpenCover/
 
-# Azure Stream Analytics local run output 
+# Azure Stream Analytics local run output
 ASALocalRun/
 
 # MSBuild Binary and Structured Log
@@ -329,7 +330,7 @@ ASALocalRun/
 # NVidia Nsight GPU debugger configuration file
 *.nvuser
 
-# MFractors (Xamarin productivity tool) working folder 
+# MFractors (Xamarin productivity tool) working folder
 .mfractor/
 
 # Mac os files

--- a/linux/base.Dockerfile
+++ b/linux/base.Dockerfile
@@ -64,8 +64,6 @@ RUN tdnf update -y --refresh && \
   openssl-libs \
   openssl-devel \
   man-db \
-  moby-cli \
-  moby-engine \
   msodbcsql18 \
   mssql-tools18 \
   mysql \

--- a/tests/command_list
+++ b/tests/command_list
@@ -188,11 +188,6 @@ compute_create
 compute_member
 compute_relabel
 consoletype
-containerd
-containerd-shim
-containerd-shim-runc-v1
-containerd-shim-runc-v2
-containerd-stress
 continue
 coproc
 coredumpctl
@@ -213,7 +208,6 @@ crond
 cronnext
 crontab
 csplit
-ctr
 ctrlaltdel
 ctstat
 curl
@@ -257,10 +251,6 @@ dltest
 dmesg
 dnsdomainname
 do
-docker
-dockerd
-docker-init
-docker-proxy
 domainname
 done
 dos2unix
@@ -1090,7 +1080,6 @@ rtmon
 rtpr
 rtstat
 ruby
-runc
 runcon
 runlevel
 run-parts
@@ -1265,7 +1254,6 @@ time
 timedatectl
 timeout
 times
-tini-static
 tipc
 tload
 tmux


### PR DESCRIPTION
A user cannot start the daemons like dockerd or related services since they don't have permissions to do so.

Fixes #436