### PR TITLE
tools-image: Clear /tmp contents as last step

### DIFF
--- a/linux/tools.Dockerfile
+++ b/linux/tools.Dockerfile
@@ -69,6 +69,8 @@ COPY ./linux/powershell/Invoke-PreparePowerShell.ps1 linux/powershell/Invoke-Pre
 
 # Remove su so users don't have su access by default.
 RUN rm -f ./linux/Dockerfile && rm -f /bin/su
+# cleanup tmp files left behind by installation
+RUN find /tmp/ -mindepth 1 -delete
 
 #Add soft links
 RUN ln -s /usr/bin/python3 /usr/bin/python


### PR DESCRIPTION
/tmp in cloudshell has a whole bunch of leftover directories and files from the various installation steps that run during the build. Clear /tmp/ as the final step before finalizing the image. This doesn't make the image smaller because the files are still present in previous layers but makes the user experience better.