### PR TITLE
command_list: Add `scalar` to the list

### DIFF
--- a/tests/command_list
+++ b/tests/command_list
@@ -1101,6 +1101,7 @@ sadf
 sar
 sasldblistusers2
 saslpasswd2
+scalar
 sclient
 scp
 screen


### PR DESCRIPTION
This binary was added in the `git` package. So adding to the commands list so that tests don't fail.