### PR TITLE
modify Ansible auth to default

### DIFF
--- a/linux/ansible/ansible
+++ b/linux/ansible/ansible
@@ -1,11 +1,6 @@
 #!/usr/bin/env bash
 
 set -e
-if [ -z "$MSI_ENDPOINT" ]; then
-  export ANSIBLE_AZURE_AUTH_SOURCE='cli'
-else
-  export ANSIBLE_AZURE_AUTH_SOURCE='msi'
-fi
 
 source /opt/ansible/bin/activate
 ansible "$@"

--- a/linux/ansible/ansible-config
+++ b/linux/ansible/ansible-config
@@ -1,11 +1,6 @@
 #!/usr/bin/env bash
 
 set -e
-if [ -z "$MSI_ENDPOINT" ]; then
-  export ANSIBLE_AZURE_AUTH_SOURCE='cli'
-else
-  export ANSIBLE_AZURE_AUTH_SOURCE='msi'
-fi
 
 source /opt/ansible/bin/activate
 ansible-config "$@"

--- a/linux/ansible/ansible-connection
+++ b/linux/ansible/ansible-connection
@@ -1,11 +1,6 @@
 #!/usr/bin/env bash
 
 set -e
-if [ -z "$MSI_ENDPOINT" ]; then
-  export ANSIBLE_AZURE_AUTH_SOURCE='cli'
-else
-  export ANSIBLE_AZURE_AUTH_SOURCE='msi'
-fi
 
 source /opt/ansible/bin/activate
 ansible-connection "$@"

--- a/linux/ansible/ansible-console
+++ b/linux/ansible/ansible-console
@@ -1,11 +1,6 @@
 #!/usr/bin/env bash
 
 set -e
-if [ -z "$MSI_ENDPOINT" ]; then
-  export ANSIBLE_AZURE_AUTH_SOURCE='cli'
-else
-  export ANSIBLE_AZURE_AUTH_SOURCE='msi'
-fi
 
 source /opt/ansible/bin/activate
 ansible-console "$@"

--- a/linux/ansible/ansible-doc
+++ b/linux/ansible/ansible-doc
@@ -1,11 +1,6 @@
 #!/usr/bin/env bash
 
 set -e
-if [ -z "$MSI_ENDPOINT" ]; then
-  export ANSIBLE_AZURE_AUTH_SOURCE='cli'
-else
-  export ANSIBLE_AZURE_AUTH_SOURCE='msi'
-fi
 
 source /opt/ansible/bin/activate
 ansible-doc "$@"

--- a/linux/ansible/ansible-galaxy
+++ b/linux/ansible/ansible-galaxy
@@ -1,11 +1,6 @@
 #!/usr/bin/env bash
 
 set -e
-if [ -z "$MSI_ENDPOINT" ]; then
-  export ANSIBLE_AZURE_AUTH_SOURCE='cli'
-else
-  export ANSIBLE_AZURE_AUTH_SOURCE='msi'
-fi
 
 source /opt/ansible/bin/activate
 ansible-galaxy "$@"

--- a/linux/ansible/ansible-inventory
+++ b/linux/ansible/ansible-inventory
@@ -1,11 +1,6 @@
 #!/usr/bin/env bash
 
 set -e
-if [ -z "$MSI_ENDPOINT" ]; then
-  export ANSIBLE_AZURE_AUTH_SOURCE='cli'
-else
-  export ANSIBLE_AZURE_AUTH_SOURCE='msi'
-fi
 
 source /opt/ansible/bin/activate
 ansible-inventory "$@"

--- a/linux/ansible/ansible-playbook
+++ b/linux/ansible/ansible-playbook
@@ -1,11 +1,6 @@
 #!/usr/bin/env bash
 
 set -e
-if [ -z "$MSI_ENDPOINT" ]; then
-  export ANSIBLE_AZURE_AUTH_SOURCE='cli'
-else
-  export ANSIBLE_AZURE_AUTH_SOURCE='msi'
-fi
 
 source /opt/ansible/bin/activate
 ansible-playbook "$@"

--- a/linux/ansible/ansible-pull
+++ b/linux/ansible/ansible-pull
@@ -1,11 +1,6 @@
 #!/usr/bin/env bash
 
 set -e
-if [ -z "$MSI_ENDPOINT" ]; then
-  export ANSIBLE_AZURE_AUTH_SOURCE='cli'
-else
-  export ANSIBLE_AZURE_AUTH_SOURCE='msi'
-fi
 
 source /opt/ansible/bin/activate
 ansible-pull "$@"

--- a/linux/ansible/ansible-vault
+++ b/linux/ansible/ansible-vault
@@ -1,11 +1,6 @@
 #!/usr/bin/env bash
 
 set -e
-if [ -z "$MSI_ENDPOINT" ]; then
-  export ANSIBLE_AZURE_AUTH_SOURCE='cli'
-else
-  export ANSIBLE_AZURE_AUTH_SOURCE='msi'
-fi
 
 source /opt/ansible/bin/activate
 ansible-vault "$@"

--- a/tests/command_list
+++ b/tests/command_list
@@ -284,7 +284,6 @@ elfedit
 elif
 else
 emacs
-emacs-29.3
 emacsclient
 enable
 enc2xs

--- a/tests/command_list
+++ b/tests/command_list
@@ -284,6 +284,7 @@ elfedit
 elif
 else
 emacs
+emacs-29.4
 emacsclient
 enable
 enc2xs


### PR DESCRIPTION
We want to authenticate using AZ-CLI instead of MSI. MSI authentication is currently causing issues with Ansible. 

With removing the ANSIBLE_AZURE_AUTH_SOURCE env variable, the authentication automatically uses the default.
https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_resource_module.html

The default has AZ-CLI as part of the queue of methods used to authenticate. If users want to specify their own method, they could through exporting the ANSIBLE_AZURE_AUTH_SOURCE env variable