### PR TITLE
action-build-push: Update the token secret value

### DIFF
--- a/.github/workflows/cloudshell-build-push.yaml
+++ b/.github/workflows/cloudshell-build-push.yaml
@@ -24,7 +24,7 @@ jobs:
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+        password: ${{ secrets.GHCR_BUILD_PUSH_TOKEN }}
 
     - name: Base image
       uses: docker/build-push-action@v6

--- a/.github/workflows/cloudshell-build-push.yaml
+++ b/.github/workflows/cloudshell-build-push.yaml
@@ -26,13 +26,18 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GHCR_BUILD_PUSH_TOKEN }}
 
+    - name: Generate Tag
+      id: tag
+      run: |
+        echo "image_tag=${{ github.sha }}-$(date '+%Y-%m-%d-%H-%M-%S')" >> $GITHUB_OUTPUT
+
     - name: Base image
       uses: docker/build-push-action@v6
       with:
         context: .
         file: linux/base.Dockerfile
         push: true
-        tags: ghcr.io/azure/cloudshell/base:${{ github.sha }},ghcr.io/azure/cloudshell/base:latest
+        tags: ghcr.io/azure/cloudshell/base:${{ steps.tag.outputs.image_tag }},ghcr.io/azure/cloudshell/base:latest
 
     - name: Tools image
       uses: docker/build-push-action@v6
@@ -40,5 +45,5 @@ jobs:
         context: .
         file: linux/tools.Dockerfile
         push: true
-        tags: ghcr.io/azure/cloudshell/tools:${{ github.sha }},ghcr.io/azure/cloudshell/tools:latest
-        build-args: IMAGE_LOCATION=ghcr.io/azure/cloudshell/base:${{ github.sha }}
+        tags: ghcr.io/azure/cloudshell/tools:${{ steps.tag.outputs.image_tag }},ghcr.io/azure/cloudshell/tools:latest
+        build-args: IMAGE_LOCATION=ghcr.io/azure/cloudshell/base:${{ steps.tag.outputs.image_tag }}


### PR DESCRIPTION
- Update the build-push-pipeline to use the personal access token to be able to push to the [ghcr.io/azure/cloudshell/base ](https://ghcr.io/azure/cloudshell/base) and ghcr.io/azure/cloudshell/tools.

- Add unique tags to the image so even if they are repeatedly built with same commit they are not overridden.