### PR TITLE
Airgap Cloud Map change

### DIFF
--- a/linux/powershell/PSCloudShellStartup.ps1
+++ b/linux/powershell/PSCloudShellStartup.ps1
@@ -18,7 +18,9 @@ $script:CloudEnvironmentMap = @{
     Fairfax = 'AzureUSGovernment'; 
     Mooncake = 'AzureChinaCloud';
     BlackForest = 'AzureGermanCloud';
-    dogfood = 'dogfood'
+    dogfood = 'dogfood';
+    USNat = 'AzureUSGovernment2';
+    USSec = 'AzureUSGovernment3';
 }
 
 # For the Az.Tools.Predictor

--- a/linux/powershell/PSCloudShellStartup.ps1
+++ b/linux/powershell/PSCloudShellStartup.ps1
@@ -20,7 +20,7 @@ $script:CloudEnvironmentMap = @{
     BlackForest = 'AzureGermanCloud';
     dogfood = 'dogfood';
     USNat = 'AzureUSGovernment2';
-    USSec = 'AzureUSGovernment3';
+    USSec = 'AzureUSGovernment3'
 }
 
 # For the Az.Tools.Predictor


### PR DESCRIPTION
In order for Azure Active Directory to be functional in AGC, we need to change the mapping so that it can point to the right environment.