### PR TITLE
build-push: Update user to github.repository_owner

### DIFF
--- a/.github/workflows/cloudshell-build-push.yaml
+++ b/.github/workflows/cloudshell-build-push.yaml
@@ -23,7 +23,7 @@ jobs:
       uses: docker/login-action@v3
       with:
         registry: ghcr.io
-        username: ${{ github.actor }}
+        username: ${{ github.repository_owner}}
         password: ${{ secrets.GHCR_BUILD_PUSH_TOKEN }}
 
     - name: Generate Tag


### PR DESCRIPTION
The current username is set to `github.actor`, change this to `github.repository_owner` to ensure that the image is pushed to the correct repository.