### PR TITLE
Remove tools moved to base image

### DIFF
--- a/linux/tools.Dockerfile
+++ b/linux/tools.Dockerfile
@@ -31,33 +31,8 @@ RUN az aks install-cli \
     && chmod +x /usr/local/bin/kubectl \
     && chmod +x /usr/local/bin/kubelogin
 
-# Install vscode
-RUN wget -nv -O vscode.tar.gz --user-agent="Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129.0.0.0 Safari/537.36 Edg/129.0.0.0" "https://code.visualstudio.com/sha/download?build=insider&os=cli-alpine-x64" \
-    && tar -xvzf vscode.tar.gz \
-    && mv ./code-insiders /bin/vscode \
-    && rm vscode.tar.gz
-
-# Install azure-developer-cli (azd)
-ENV AZD_IN_CLOUDSHELL 1
-ENV AZD_SKIP_UPDATE_CHECK 1
-RUN curl -fsSL https://aka.ms/install-azd.sh | bash
-
 RUN mkdir -p /usr/cloudshell
 WORKDIR /usr/cloudshell
-
-# Install Office 365 CLI templates
-RUN npm install -q -g @pnp/cli-microsoft365
-
-# Install Bicep CLI
-RUN curl -Lo bicep https://github.com/Azure/bicep/releases/latest/download/bicep-linux-x64 \
-    && chmod +x ./bicep \
-    && mv ./bicep /usr/local/bin/bicep \
-    && bicep --help
-
-# Temp: fix ansible modules. Proper fix is to update base layer to use regular python for Ansible.
-RUN mkdir -p /usr/share/ansible/collections/ansible_collections/azure/azcollection/ \
-    && wget -nv -q -O /usr/share/ansible/collections/ansible_collections/azure/azcollection/requirements.txt https://raw.githubusercontent.com/ansible-collections/azure/dev/requirements.txt \
-    && /opt/ansible/bin/python -m pip install -r /usr/share/ansible/collections/ansible_collections/azure/azcollection/requirements.txt
 
 # Powershell telemetry
 ENV POWERSHELL_DISTRIBUTION_CHANNEL=CloudShell \
@@ -76,10 +51,6 @@ RUN /usr/bin/pwsh -File ./powershell/setupPowerShell.ps1 -image Base && \
 
 # Remove su so users don't have su access by default.
 RUN rm -f ./linux/Dockerfile && rm -f /bin/su
-
-#Add soft links
-RUN ln -sf /usr/bin/python3 /usr/bin/python
-RUN ln -sf /usr/bin/node /usr/bin/nodejs
 
 # Add user's home directories to PATH at the front so they can install tools which
 # override defaults


### PR DESCRIPTION
Following components were moved to base image:

- Ansible galaxy
- vscode
- Azure Developer CLI
- Bicep

This commit removes the installation of these
components from the tools image.