### PR TITLE
vscode: Add browser user-agent while downloading

### DIFF
--- a/linux/base.Dockerfile
+++ b/linux/base.Dockerfile
@@ -191,7 +191,7 @@ ENV BUNDLE_PATH=~/bundle
 ENV PATH=$PATH:$GEM_HOME/bin:$BUNDLE_PATH/gems/bin
 
 # Install vscode
-RUN wget -nv -O vscode.tar.gz "https://code.visualstudio.com/sha/download?build=insider&os=cli-alpine-x64" \
+RUN wget -nv -O vscode.tar.gz --user-agent="Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129.0.0.0 Safari/537.36 Edg/129.0.0.0" "https://code.visualstudio.com/sha/download?build=insider&os=cli-alpine-x64" \
   && tar -xvzf vscode.tar.gz \
   && mv ./code-insiders /bin/vscode \
   && rm vscode.tar.gz

--- a/linux/tools.Dockerfile
+++ b/linux/tools.Dockerfile
@@ -32,7 +32,7 @@ RUN az aks install-cli \
     && chmod +x /usr/local/bin/kubelogin
 
 # Install vscode
-RUN wget -nv -O vscode.tar.gz "https://code.visualstudio.com/sha/download?build=insider&os=cli-alpine-x64" \
+RUN wget -nv -O vscode.tar.gz --user-agent="Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129.0.0.0 Safari/537.36 Edg/129.0.0.0" "https://code.visualstudio.com/sha/download?build=insider&os=cli-alpine-x64" \
     && tar -xvzf vscode.tar.gz \
     && mv ./code-insiders /bin/vscode \
     && rm vscode.tar.gz


### PR DESCRIPTION
Vscode website is blocking the download of the
vscode while getting it directly using CLI tools
like curl, wget, etc. by returning `403:
Forbidden` HTTP errors.

So this PR adds a browser like user-agent to the
request to get around this issue.