### PR TITLE
base: Fix the terraform version

### DIFF
--- a/linux/base.Dockerfile
+++ b/linux/base.Dockerfile
@@ -142,6 +142,7 @@ ENV NODE_OPTIONS=--tls-cipher-list='ECDHE-RSA-AES128-GCM-SHA256:!RC4'
 # Get latest version of Terraform.
 # Customers require the latest version of Terraform.
 RUN TF_VERSION=$(curl -s https://checkpoint-api.hashicorp.com/v1/check/terraform | jq -r -M ".current_version") \
+  && TF_VERSION="${TF_VERSION#v}" \
   && wget -nv -O terraform.zip "https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_${TF_VERSION}_linux_amd64.zip" \
   && wget -nv -O terraform.sha256 "https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_${TF_VERSION}_SHA256SUMS" \
   && echo "$(grep "${TF_VERSION}_linux_amd64.zip" terraform.sha256 | awk '{print $1}')  terraform.zip" | sha256sum -c \


### PR DESCRIPTION
The URL that returns the terraform version has started prefixing `v` for the version number in the field: `current_version`.

```json
{"product":"terraform","current_version":"v1.11.0",
"current_release":1740666694,
"current_download_url":"https://releases.hashicorp.com/terraform/1.11.0",
"current_changelog_url":"https://github.com/hashicorp/terraform/blob/v1.11.0/CHANGELOG.md",
"project_website":"https://www.terraform.io","alerts":[]}
```

This extra `v` generates erroneous link and thus when we try to download we get a 404. For example the link becomes:

```
https://releases.hashicorp.com/terraform/v1.11.0/terraform_v1.11.0_linux_amd64.zip
```

Instead of:

```
https://releases.hashicorp.com/terraform/1.11.0/terraform_1.11.0_linux_amd64.zip
```

This commit removes that extra `v` to download the correct build of terraform.