### PR TITLE
Changed tips to link to release notes

### DIFF
--- a/linux/powershell/PSCloudShellUtility/tips.json
+++ b/linux/powershell/PSCloudShellUtility/tips.json
@@ -1,6 +1,5 @@
 {
   "items": [
-    "Azure Cloud Shell now includes Predictive IntelliSense! Learn more: https://aka.ms/CloudShell/IntelliSense",
-    "SqlServer has been updated to Version 22!"
+    "For the latest updates and release notes, please visit: https://aka.ms/cloud-shell-release-notes."
   ]
 }


### PR DESCRIPTION
The current tips in the `tips.json` file have been updated to link to the release notes instead of 2 year old tips about Predictive IntelliSense and SQL Server updates.