### PR TITLE
CI: Switch the "maximize build space" action

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,15 +24,13 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - name: Maximize build space
-        uses: easimon/maximize-build-space@master
+        uses: AdityaGarg8/remove-unwanted-software@v5
         with:
-          root-reserve-mb: '16384'
-          temp-reserve-mb: '100'
-          swap-size-mb: '8192'
           remove-dotnet: 'true'
           remove-android: 'true'
           remove-haskell: 'true'
           remove-codeql: 'true'
+          remove-docker-images: 'true'
 
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v3


### PR DESCRIPTION
The existing action is not maintained any more.

This is the available space before cleanup:

```
Filesystem     Size  Used Avail Use% Mounted on
/dev/root       72G   47G   25G  66% /
```

This is what the old action did:

```
Filesystem     Size  Used Avail Use% Mounted on
/dev/root       72G   56G   16G  78% /
```

This is what the new action does:

```
Filesystem     Size  Used Avail Use% Mounted on
/dev/root       72G   27G   45G  38% /
```