### PR TITLE
linux: base.Dockerfile: Add ig and kubectl-gadget

### DIFF
--- a/linux/base.Dockerfile
+++ b/linux/base.Dockerfile
@@ -20,6 +20,7 @@ COPY linux/tdnfinstall.sh .
 
 RUN tdnf update -y --refresh && \
   bash ./tdnfinstall.sh \
+  azurelinux-repos-cloud-native \
   azurelinux-repos-extended \
   azurelinux-repos-ms-non-oss-3.0 && \
   tdnf repolist --refresh && \
@@ -129,6 +130,8 @@ RUN tdnf update -y --refresh && \
   slirp4netns \
   msodbcsql18 \
   mssql-tools18 \
+  kubectl-gadget \
+  ig \
   gettext && \
   tdnf clean all && \
   rm -rf /var/cache/tdnf/*

--- a/tests/command_list
+++ b/tests/command_list
@@ -1195,7 +1195,6 @@ ssh
 ssh-add
 ssh-agent
 ssh-copy-id
-sshd
 ssh-keygen
 ssh-keyscan
 sst_dump

--- a/tests/command_list
+++ b/tests/command_list
@@ -391,6 +391,7 @@ fuse-overlayfs
 fuser
 fusermount3
 g++
+gadgetctl
 gawk
 gawk-5.2.2
 gawkbug
@@ -557,6 +558,7 @@ if
 ifconfig
 ifnames
 ifstat
+ig
 in
 indxbib
 infocmp
@@ -662,6 +664,7 @@ ksba-config
 kswitch
 ktutil
 kubectl
+kubectl-gadget
 kubelogin
 kvno
 last


### PR DESCRIPTION
This PR adds kubectl-gadget, the k8s plugin to deploy Inspektor Gadget to k8sn and ig, the local CLI flavor of Inspektor Gadget, to CloudShell.
Users can now deploy Inspektor Gadget and interact with the gadget daemonset by using kubectl gadget.
They can dialog with a remote ig instance using gadgetctl.