### PR TITLE
Remove temp fix for the tools image

### DIFF
--- a/linux/tools.Dockerfile
+++ b/linux/tools.Dockerfile
@@ -11,22 +11,6 @@ FROM ${IMAGE_LOCATION}
 
 LABEL org.opencontainers.image.source="https://github.com/Azure/CloudShell"
 
-# Temporarily add in this code. We can remove it once we cache the base image.
-RUN tdnf update -y --refresh && \
-    bash ./tdnfinstall.sh \
-    azurelinux-repos-cloud-native \
-    azurelinux-repos-extended \
-    azurelinux-repos-ms-non-oss-3.0 && \
-    tdnf repolist --refresh && \
-    bash ./tdnfinstall.sh \
-    msodbcsql18 \
-    mssql-tools18 \
-    kubectl-gadget \
-    ig && \
-    tdnf clean all && \
-    rm -rf /var/cache/tdnf/*
-        
-
 RUN tdnf clean all && \
     tdnf repolist --refresh && \
     ACCEPT_EULA=Y tdnf update -y && \


### PR DESCRIPTION
Our base image has now been cached and our tools image is pointing to it. We can remove the additional package installation from our tools image.