### PR TITLE
GitHub Action to update Pinned libraries

### DIFF
--- a/.github/workflows/update-pinned-libs.yml
+++ b/.github/workflows/update-pinned-libs.yml
@@ -2,8 +2,8 @@ name: Update Pinned Library Versions
 
 on:
   schedule:
-    # Check for updates every day at 6:00 AM UTC
-    - cron: '0 6 * * *'
+    # Check for updates every 2 weeks (1st and 15th of each month) at 6:00 AM UTC
+    - cron: '0 6 1,15 * *'
   workflow_dispatch: # Allow manual trigger
 
 jobs:


### PR DESCRIPTION
As part of doing controlled updates to libraries/packages, some of the updates to packages that are downloaded outside of az linux are pinned to specific version. This GitHub Action is a workflow that checks if the library has gotten updated and if so will upgrade the pinned version and auto generate a PR.