### PR TITLE
Pin trivy-action to known secure version

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Scan base image with Trivy
         id: trivy-base-scan
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           scan-type: 'image'
           image-ref: base_cloudshell
@@ -61,7 +61,7 @@ jobs:
 
       - name: Scan Tools image with Trivy
         id: trivy-tools-scan
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           scan-type: 'image'
           image-ref: tools_cloudshell


### PR DESCRIPTION
Resolves #599 by pinning the `trivy-action` to a known safe version (0.35.0) identified by Microsoft Security.