### PR TITLE
chore: Update base image container reference

### DIFF
--- a/linux/tools.Dockerfile
+++ b/linux/tools.Dockerfile
@@ -4,7 +4,7 @@
 
 # To build yourself locally, override this location with a local image tag. See README.md for more detail
 
-ARG IMAGE_LOCATION=cloudconregprd.azurecr.io/public/azure-cloudshell:base.master.bf06a3e8.20260305.1
+ARG IMAGE_LOCATION=cloudconregprd.azurecr.io/public/azure-cloudshell:base.master.13613232.20260406.1
 
 # Copy from base build
 FROM ${IMAGE_LOCATION}


### PR DESCRIPTION
Updates the base image reference to the most recently cached cloud shell version.