### PR TITLE
Switch istioctl to be installed through the Azure Linux package feed

### DIFF
--- a/.github/workflows/update-pinned-libs.yml
+++ b/.github/workflows/update-pinned-libs.yml
@@ -3,7 +3,7 @@ name: Update Pinned Library Versions
 on:
   schedule:
     # Check for updates every 2 weeks (1st and 15th of each month) at 6:00 AM UTC
-    - cron: '0 6 1,15 * *'
+    - cron: "0 6 1,15 * *"
   workflow_dispatch: # Allow manual trigger
 
 jobs:
@@ -12,54 +12,12 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-
-      - name: Get current Istio version
-        id: current-istio
-        run: |
-          CURRENT_VERSION=$(grep 'ENV ISTIO_VERSION=' linux/base.Dockerfile | cut -d'=' -f2)
-          if [ -z "${CURRENT_VERSION}" ]; then
-            echo "Error: Unable to determine current Istio version from linux/base.Dockerfile" >&2
-            exit 1
-          fi
-          echo "version=${CURRENT_VERSION}" >> $GITHUB_OUTPUT
-          echo "Current Istio version: ${CURRENT_VERSION}"
-
-      - name: Get latest Istio version
-        id: latest-istio
-        run: |
-          set -e
-          LATEST_VERSION=$(curl -fsSL https://api.github.com/repos/istio/istio/releases/latest | jq -er '.tag_name') || {
-            echo "Error: Failed to fetch latest Istio release information from GitHub API." >&2
-            exit 1
-          }
-          
-          if [ -z "${LATEST_VERSION}" ] || [ "${LATEST_VERSION}" = "null" ]; then
-            echo "Error: Received empty or invalid latest Istio version from GitHub API." >&2
-            exit 1
-          fi
-          
-          echo "version=${LATEST_VERSION}" >> $GITHUB_OUTPUT
-          echo "Latest Istio version: ${LATEST_VERSION}"
-
-      - name: Compare Istio versions
-        id: compare-istio
-        run: |
-          CURRENT="${{ steps.current-istio.outputs.version }}"
-          LATEST="${{ steps.latest-istio.outputs.version }}"
-          
-          if [ "${CURRENT}" != "${LATEST}" ]; then
-            echo "needs_update=true" >> $GITHUB_OUTPUT
-            echo "Istio update needed: ${CURRENT} -> ${LATEST}"
-          else
-            echo "needs_update=false" >> $GITHUB_OUTPUT
-            echo "Istio already on latest version: ${CURRENT}"
-          fi
 
       - name: Get current RootlessKit version
         id: current-rootlesskit
@@ -80,12 +38,12 @@ jobs:
             echo "Error: Failed to fetch latest RootlessKit release information from GitHub API." >&2
             exit 1
           }
-          
+
           if [ -z "${LATEST_VERSION}" ] || [ "${LATEST_VERSION}" = "null" ]; then
             echo "Error: Received empty or invalid latest RootlessKit version from GitHub API." >&2
             exit 1
           fi
-          
+
           echo "version=${LATEST_VERSION}" >> $GITHUB_OUTPUT
           echo "Latest RootlessKit version: ${LATEST_VERSION}"
 
@@ -94,7 +52,7 @@ jobs:
         run: |
           CURRENT="${{ steps.current-rootlesskit.outputs.version }}"
           LATEST="${{ steps.latest-rootlesskit.outputs.version }}"
-          
+
           if [ "${CURRENT}" != "${LATEST}" ]; then
             echo "needs_update=true" >> $GITHUB_OUTPUT
             echo "RootlessKit update needed: ${CURRENT} -> ${LATEST}"
@@ -102,26 +60,6 @@ jobs:
             echo "needs_update=false" >> $GITHUB_OUTPUT
             echo "RootlessKit already on latest version: ${CURRENT}"
           fi
-
-      - name: Update Istio in Dockerfile
-        if: steps.compare-istio.outputs.needs_update == 'true'
-        run: |
-          LATEST="${{ steps.latest-istio.outputs.version }}"
-
-          # Ensure the expected ENV ISTIO_VERSION line exists before attempting to update
-          if ! grep -q '^ENV ISTIO_VERSION=' linux/base.Dockerfile; then
-            echo "Error: Could not find 'ENV ISTIO_VERSION=' line in linux/base.Dockerfile"
-            exit 1
-          fi
-
-          sed -i "s/^ENV ISTIO_VERSION=.*/ENV ISTIO_VERSION=${LATEST}/" linux/base.Dockerfile
-
-          # Verify that the update was applied successfully
-          if ! grep -q "^ENV ISTIO_VERSION=${LATEST}$" linux/base.Dockerfile; then
-            echo "Error: Failed to update ISTIO_VERSION to ${LATEST} in linux/base.Dockerfile"
-            exit 1
-          fi
-          echo "Updated ISTIO_VERSION to ${LATEST}"
 
       - name: Update RootlessKit in Dockerfile
         if: steps.compare-rootlesskit.outputs.needs_update == 'true'
@@ -142,7 +80,7 @@ jobs:
           echo "Updated ROOTLESSKIT_VERSION to ${LATEST}"
 
       - name: Create and push branch with updates
-        if: steps.compare-istio.outputs.needs_update == 'true' || steps.compare-rootlesskit.outputs.needs_update == 'true'
+        if: steps.compare-rootlesskit.outputs.needs_update == 'true'
         run: |
           BRANCH_NAME="update-pinned-libs-$(date +%Y%m%d)"
           git config user.name "github-actions[bot]"
@@ -155,39 +93,32 @@ jobs:
         id: push-branch
 
       - name: Create Pull Request
-        if: steps.compare-istio.outputs.needs_update == 'true' || steps.compare-rootlesskit.outputs.needs_update == 'true'
+        if: steps.compare-rootlesskit.outputs.needs_update == 'true'
         env:
           GH_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
         run: |
-          CURRENT_ISTIO="${{ steps.current-istio.outputs.version }}"
-          LATEST_ISTIO="${{ steps.latest-istio.outputs.version }}"
           CURRENT_ROOTLESSKIT="${{ steps.current-rootlesskit.outputs.version }}"
           LATEST_ROOTLESSKIT="${{ steps.latest-rootlesskit.outputs.version }}"
           BRANCH_NAME="${{ steps.push-branch.outputs.branch }}"
-          
+
           UPDATES=""
           RELEASE_NOTES=""
-          
-          if [ "${{ steps.compare-istio.outputs.needs_update }}" == "true" ]; then
-            UPDATES="${UPDATES}- **Istio**: ${CURRENT_ISTIO} to ${LATEST_ISTIO}\n"
-            RELEASE_NOTES="${RELEASE_NOTES}- Istio ${LATEST_ISTIO}: https://github.com/istio/istio/releases/tag/${LATEST_ISTIO}\n"
-          fi
-          
+
           if [ "${{ steps.compare-rootlesskit.outputs.needs_update }}" == "true" ]; then
             UPDATES="${UPDATES}- **RootlessKit**: ${CURRENT_ROOTLESSKIT} to ${LATEST_ROOTLESSKIT}\n"
             RELEASE_NOTES="${RELEASE_NOTES}- RootlessKit ${LATEST_ROOTLESSKIT}: https://github.com/rootless-containers/rootlesskit/releases/tag/${LATEST_ROOTLESSKIT}\n"
           fi
-          
+
           gh pr create \
             --title "chore: update pinned library versions" \
             --body "## Automated Library Version Updates
-          
+
           This PR updates the following pinned library versions:
-          
+
           ${UPDATES}
           ### Changes
           - Updated version variables in linux/base.Dockerfile
-          
+
           ### Release Notes
           ${RELEASE_NOTES}
           ---

--- a/linux/base.Dockerfile
+++ b/linux/base.Dockerfile
@@ -137,8 +137,8 @@ RUN tdnf update -y --refresh && \
   tdnf clean all && \
   rm -rf /var/cache/tdnf/*
 
-ENV NPM_CONFIG_LOGLEVEL warn
-ENV NODE_ENV production
+ENV NPM_CONFIG_LOGLEVEL=warn
+ENV NODE_ENV=production
 ENV NODE_OPTIONS=--tls-cipher-list='ECDHE-RSA-AES128-GCM-SHA256:!RC4'
 
 # Get latest version of Terraform.

--- a/linux/base.Dockerfile
+++ b/linux/base.Dockerfile
@@ -55,6 +55,7 @@ RUN tdnf update -y --refresh && \
   initscripts \
   iptables \
   iputils \
+  istio-istioctl \
   msopenjdk-17 \
   jq \
   less \
@@ -169,18 +170,6 @@ RUN chmod 755 /usr/local/bin/ansible* \
   && mkdir -p /usr/share/ansible/collections/ansible_collections/azure/azcollection/ \
   && wget -nv -q -O /usr/share/ansible/collections/ansible_collections/azure/azcollection/requirements.txt https://raw.githubusercontent.com/ansible-collections/azure/dev/requirements.txt \
   && /opt/ansible/bin/python -m pip install -r /usr/share/ansible/collections/ansible_collections/azure/azcollection/requirements.txt
-
-
-# Install specific version of Istio from GitHub releases
-ENV ISTIO_VERSION=1.29.1
-RUN export TMP_DIR=$(mktemp -d) \
-  && cd "${TMP_DIR}" \
-  && curl -L https://github.com/istio/istio/releases/download/${ISTIO_VERSION}/istio-${ISTIO_VERSION}-linux-amd64.tar.gz -o istio.tar.gz \
-  && tar -xzf istio.tar.gz \
-  && mv istio-${ISTIO_VERSION}/bin/istioctl /usr/local/bin/istioctl \
-  && chmod 755 /usr/local/bin/istioctl \
-  && cd / \
-  && rm -rf "${TMP_DIR}"
 
 ENV GOROOT="/usr/lib/golang"
 # TODO: Move adding mssql-tools18 path addition to agent image


### PR DESCRIPTION
We currently install `istioctl` from the official [Github releases](https://github.com/istio/istio/releases) while building the base docker image. This was done to ensure the version of istio was up-to-date with the latest.

This PR switches the install location to come from the Azure Linux package feed.  Per discussions with the team publishing the packages, they maintain a 5-day SLA for republishing newly released versions to the feed. The Azure Linux package feed version is built to ensure compliance with our internal security scanning tools.