### PR TITLE
Update nodejs to v24

### DIFF
--- a/linux/base.Dockerfile
+++ b/linux/base.Dockerfile
@@ -25,8 +25,8 @@ RUN tdnf update -y --refresh && \
   azurelinux-repos-ms-non-oss-3.0 && \
   tdnf repolist --refresh && \
   bash ./tdnfinstall.sh \
-  nodejs \
-  nodejs-npm \
+  nodejs24 \
+  nodejs24-npm \
   xz \
   git \
   gpgme \

--- a/tests/PSinLinuxCloudShellImage.Tests.ps1
+++ b/tests/PSinLinuxCloudShellImage.Tests.ps1
@@ -18,7 +18,7 @@ Describe "Various programs installed with expected versions" {
 
     It "Static Versions" {
         # These programs are installed explicitly with specific versions
-        $script:pmap["Node.JS"].Version | Should -Be '20.14.0'
+        $script:pmap["Node.JS"].Version | Should -Be '24.14.1'
         $script:pmap["PowerShell"].Version | Should -BeLike '7.6*'
     }
 


### PR DESCRIPTION
CloudShell currently installs Node 20 which will become [EOL on April 30](https://nodejs.org/en/about/previous-releases). This updates the image to bundle NodeJS 24 which is the current LTS release.