### PR TITLE
Adds --no-compile flag to pip installs

### DIFF
--- a/linux/base.Dockerfile
+++ b/linux/base.Dockerfile
@@ -162,14 +162,14 @@ COPY ./linux/ansible/ansible*  /usr/local/bin/
 RUN chmod 755 /usr/local/bin/ansible* \
   && cd /opt \
   && virtualenv -p python3 ansible \
-  && /bin/bash -c "source ansible/bin/activate && pip3 list --format=freeze | cut -d '=' -f1 | xargs -n1 pip3 install -U && pip3 install ansible && pip3 install pywinrm\>\=0\.2\.2 && deactivate" \
+  && /bin/bash -c "source ansible/bin/activate && pip3 list --format=freeze | cut -d '=' -f1 | xargs -n1 pip3 install --no-compile -U && pip3 install --no-compile ansible && pip3 install --no-compile 'pywinrm>=0.2.2' && deactivate" \
   && rm -rf ~/.local/share/virtualenv/ \
-  && rm -rf ~/.cache/pip/ \
   && ansible-galaxy collection install azure.azcollection --force -p /usr/share/ansible/collections \
   # Temp: Proper fix is to use regular python for Ansible.
   && mkdir -p /usr/share/ansible/collections/ansible_collections/azure/azcollection/ \
   && wget -nv -q -O /usr/share/ansible/collections/ansible_collections/azure/azcollection/requirements.txt https://raw.githubusercontent.com/ansible-collections/azure/dev/requirements.txt \
-  && /opt/ansible/bin/python -m pip install -r /usr/share/ansible/collections/ansible_collections/azure/azcollection/requirements.txt
+  && /opt/ansible/bin/python -m pip install --no-compile -r /usr/share/ansible/collections/ansible_collections/azure/azcollection/requirements.txt \
+  && rm -rf ~/.cache/pip/ 
 
 ENV GOROOT="/usr/lib/golang"
 # TODO: Move adding mssql-tools18 path addition to agent image


### PR DESCRIPTION
This tells pip to not pre-compile the python files from installed packages. Testing locally, this shaves 1.8GB from the overall Base image size.  The downside will be for ansible users, the first run of the command will now take longer because it will need to run that compile step.