### PR TITLE
Updates remaining CBL-Mariner refs to AzLinux 3

### DIFF
--- a/docs/add-package-into-cloudshell.md
+++ b/docs/add-package-into-cloudshell.md
@@ -15,7 +15,9 @@ mkdir -p ~/.local/bin/
 tar -zxf oras_${VERSION}_*.tar.gz -C ~/.local/bin/ oras
 rm oras_${VERSION}_*.tar.gz
 ```
+
 Reference: https://oras.land/docs/installation#linux
+
 > [!NOTE]
 > If you would like your package to persist across multiple Cloud Shell sessions, a storage account is required.
 
@@ -32,14 +34,13 @@ To meet security and compliance requirements, all packages must be installed fro
 > [!NOTE]
 > The instructions assume Azure Linux 2.0 because CloudShell is currently based on Azure Linux 2.0
 
-Please check if the package is available here:
-https://packages.microsoft.com/cbl-mariner/2.0/prod/base/x86_64/Packages/
+Please check if the package is available here: <https://packages.microsoft.com/azurelinux/3.0/prod/>
 
 Alternatively, you can use `docker` to check if a package exists in Azure Linux. Run the following command in a terminal:
 
+```sh
+docker run mcr.microsoft.com/azurelinux/base/core:3.0 bash -c "tdnf list | grep <package name>"
 ```
-docker run mcr.microsoft.com/cbl-mariner/base/core:2.0 bash -c "tdnf list | grep <package name>"
- ```
 
 ### Requesting Azure Linux package repository for the package
 
@@ -51,10 +52,9 @@ To start the process of adding your package to Azure Linux repository, please op
 
 To track this request in Cloud Shell, we will need an issue on GitHub. If the package is already in the Azure Linux repository, please open a pull request to include it, as described below. If the package is not yet available in the Azure Linux repo please open an issue making the request for the addition and link to the issue you raised in the Azure Linux GitHub repo in the previous step. Of course,before taking either of these steps, check if someone else has already made the request. If they have, please add your thumbs up so we know you need it too.
 
-Please create a PR for adding the package in [base.Dockerfile](https://github.com/Azure/CloudShell/blob/master/linux/base.Dockerfile)'s package list as shown below: 
+Please create a PR for adding the package in [base.Dockerfile](https://github.com/Azure/CloudShell/blob/master/linux/base.Dockerfile)'s package list as shown below:
 
-
-```
+```dockerfile
 RUN tdnf update -y --refresh && \
   bash ./tdnfinstall.sh \
   mariner-repos-extended && \
@@ -65,5 +65,3 @@ RUN tdnf update -y --refresh && \
   ... \
   <package name>
 ```
-
-

--- a/docs/add-package-into-cloudshell.md
+++ b/docs/add-package-into-cloudshell.md
@@ -32,7 +32,7 @@ To meet security and compliance requirements, all packages must be installed fro
 ### Check if package is available in Azure Linux
 
 > [!NOTE]
-> The instructions assume Azure Linux 2.0 because CloudShell is currently based on Azure Linux 2.0
+> The instructions assume Azure Linux 3.0 because CloudShell is currently based on Azure Linux 3.0
 
 Please check if the package is available here: <https://packages.microsoft.com/azurelinux/3.0/prod/>
 

--- a/linux/base.Dockerfile
+++ b/linux/base.Dockerfile
@@ -8,10 +8,10 @@
 # of the base docker file stored in a container registry. This avoids accidentally introducing a change in
 # the base image
 
-# CBL-Mariner is an internal Linux distribution for Microsoft’s cloud infrastructure and edge products and services.
-# CBL-Mariner is designed to provide a consistent platform for these devices and services and will enhance Microsoft’s
+# Azure Linux is an internal Linux distribution for Microsoft’s cloud infrastructure and edge products and services. 
+# Azure Linux is designed to provide a consistent platform for these devices and services and will enhance Microsoft’s 
 # ability to stay current on Linux updates.
-# https://github.com/microsoft/CBL-Mariner
+# https://github.com/microsoft/azurelinux
 FROM mcr.microsoft.com/azurelinux/base/core:3.0
 LABEL org.opencontainers.image.source="https://github.com/Azure/CloudShell"
 

--- a/tests/PSinLinuxCloudShellImage.Tests.ps1
+++ b/tests/PSinLinuxCloudShellImage.Tests.ps1
@@ -8,12 +8,12 @@ Describe "Various programs installed with expected versions" {
         }
     }
 
-    It "Base OS - CBL-Mariner 2.0" {
+    It "Base OS - Azure Linux 3.0" {
 
         [System.Environment]::OSVersion.Platform | Should -Be 'Unix'
         $osDetails = Get-Content /etc/*release
-        $osDetails | Where-Object {$_.Contains('VERSION_ID="3.0"')} | Should -Not -BeNullOrEmpty
-        $osDetails | Where-Object {$_.Contains('NAME="Microsoft Azure Linux"')} | Should -Not -BeNullOrEmpty
+        $osDetails | Where-Object { $_.Contains('VERSION_ID="3.0"') } | Should -Not -BeNullOrEmpty
+        $osDetails | Where-Object { $_.Contains('NAME="Microsoft Azure Linux"') } | Should -Not -BeNullOrEmpty
     }
 
     It "Static Versions" {
@@ -57,12 +57,12 @@ Describe "Various programs installed with expected versions" {
             "pwsh-preview"
         )
 
-        $specialmatcher = ($special | % { "($_)"}) -join "|"
+        $specialmatcher = ($special | % { "($_)" }) -join "|"
 
-        $missing = ($command_diffs | ? { $_ -like "<*" } | % { $_.Replace("< ", "") } | ? { $_ -notmatch $specialmatcher}) -join ","
+        $missing = ($command_diffs | ? { $_ -like "<*" } | % { $_.Replace("< ", "") } | ? { $_ -notmatch $specialmatcher }) -join ","
         $missing | Should -Be "" -Because "Commands '$missing' should be installed on the path but were not found. No commands should have been removed unexpectedly. If one really should be deleted, remove it from command_list"
 
-        $added = ($command_diffs | ? { $_ -like ">*" } | % { $_.Replace("> ", "") } | ? { $_ -notmatch $specialmatcher}) -join ","
+        $added = ($command_diffs | ? { $_ -like ">*" } | % { $_.Replace("> ", "") } | ? { $_ -notmatch $specialmatcher }) -join ","
         $added | Should -Be "" -Because "Commands '$added' were unexpectedly found on the path. Probably this is good, in which case add them to command_list"
 
     }
@@ -100,7 +100,7 @@ Describe "PowerShell Modules" {
 
         $special = @("PSReadLine")
 
-        (Get-Module -ListAvailable | Group-Object Name | Where-Object { $_.Count -gt 1 } ) | Where-Object { $_.Name -notin $special} | Should -Be $null
+        (Get-Module -ListAvailable | Group-Object Name | Where-Object { $_.Count -gt 1 } ) | Where-Object { $_.Name -notin $special } | Should -Be $null
 
     }
 


### PR DESCRIPTION
Updating docs to point finalize renames to Azure Linux 3 from CBL-Mariner 2.