### PR TITLE
Removed gozip dependencies for Azure Functions

### DIFF
--- a/linux/tools.Dockerfile
+++ b/linux/tools.Dockerfile
@@ -35,10 +35,8 @@ RUN az aks install-cli \
 RUN wget -nv -O Azure.Functions.Cli.zip `curl -fSsL https://api.github.com/repos/Azure/azure-functions-core-tools/releases/latest | grep "url.*linux-x64" | grep -v "sha2" | cut -d '"' -f4` \
     && unzip -d azure-functions-cli Azure.Functions.Cli.zip \
     && chmod +x azure-functions-cli/func \
-    && chmod +x azure-functions-cli/gozip \
     && mv -v azure-functions-cli /opt \
     && ln -sf /opt/azure-functions-cli/func /usr/bin/func \
-    && ln -sf /opt/azure-functions-cli/gozip /usr/bin/gozip \
     && rm -r Azure.Functions.Cli.zip
 
 RUN mkdir -p /usr/cloudshell

--- a/tests/command_list
+++ b/tests/command_list
@@ -459,7 +459,6 @@ gnutls-cli-debug
 gnutls-serv
 go
 gofmt
-gozip
 gp-archive
 gpasswd
 gp-collect-app


### PR DESCRIPTION
Azure Functions CLI removed references to gozip utility

Azure Functions Core Tools releases: 
[https://github.com/Azure/azure-functions-core-tools/releases](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)

Latest release (includes gozip removal): 

[https://github.com/Azure/azure-functions-core-tools/releases/tag/4.11.0](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)

Related failing CloudShell CI job: [https://github.com/Azure/CloudShell/actions/runs/26484349933/job/77988423522](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)

This pull request removes references to the `gozip` utility from both the Docker build process and the test command list. This simplifies the environment by eliminating an unused or unnecessary binary.

Removals related to `gozip`:

* Removed the step that made `gozip` executable and created a symlink for it in the Dockerfile, so `gozip` is no longer installed or available in the container (`linux/tools.Dockerfile`).
* Removed `gozip` from the test command list, so it is no longer expected or checked in automated tests (`tests/command_list`).