### PR TITLE
Update tools.Dockerfile base image tag to 20260518 release

### DIFF
--- a/linux/tools.Dockerfile
+++ b/linux/tools.Dockerfile
@@ -4,7 +4,7 @@
 
 # To build yourself locally, override this location with a local image tag. See README.md for more detail
 
-ARG IMAGE_LOCATION=cloudconregprd.azurecr.io/public/azure-cloudshell:base.master.78b9a056.20260421.1
+ARG IMAGE_LOCATION=cloudconregprd.azurecr.io/public/azure-cloudshell:base.master.894ed5cf.20260518.1
 
 # Copy from base build
 FROM ${IMAGE_LOCATION}


### PR DESCRIPTION
**Summary**
This PR updates the tools image base reference to the latest 20260518 base release.

**Change**
Updated the image tag in [tools.Dockerfile](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)

**Why**
Keeps the tools image aligned with the current base image published for CloudShell.
Pulls in the latest base-level updates from that release line.

**Validation**
Branch is clean relative to master scope:
1 commit ahead, 0 behind

1 file changed: [tools.Dockerfile](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)