### PR TITLE
Update PowerShell tests to Pester v6

### DIFF
--- a/tests/PSinLinuxCloudShellImage.Tests.ps1
+++ b/tests/PSinLinuxCloudShellImage.Tests.ps1
@@ -1,4 +1,4 @@
-Describe "Various programs installed with expected versions" -Tag "StandardUser" {
+Describe "Various programs installed with expected versions" -Tag "CloudShellUser" {
 
     BeforeAll {
         $script:packages = Get-PackageVersion

--- a/tests/PSinLinuxCloudShellImage.Tests.ps1
+++ b/tests/PSinLinuxCloudShellImage.Tests.ps1
@@ -18,7 +18,7 @@ Describe "Various programs installed with expected versions" {
 
     It "Static Versions" {
         # These programs are installed explicitly with specific versions
-        $script:pmap["Node.JS"].Version | Should-Be '24.14.1'
+        $script:pmap["Node.JS"].Version | Should-BeLikeString '24.*'
         $script:pmap["PowerShell"].Version | Should-BeLikeString '7.6*'
     }
 

--- a/tests/PSinLinuxCloudShellImage.Tests.ps1
+++ b/tests/PSinLinuxCloudShellImage.Tests.ps1
@@ -1,4 +1,4 @@
-Describe "Various programs installed with expected versions" {
+Describe "Various programs installed with expected versions" -Tag "StandardUser" {
 
     BeforeAll {
         $script:packages = Get-PackageVersion

--- a/tests/PSinLinuxCloudShellImage.Tests.ps1
+++ b/tests/PSinLinuxCloudShellImage.Tests.ps1
@@ -10,16 +10,16 @@ Describe "Various programs installed with expected versions" {
 
     It "Base OS - Azure Linux 3.0" {
 
-        [System.Environment]::OSVersion.Platform | Should -Be 'Unix'
+        [System.Environment]::OSVersion.Platform | Should-Be 'Unix'
         $osDetails = Get-Content /etc/*release
-        $osDetails | Where-Object { $_.Contains('VERSION_ID="3.0"') } | Should -Not -BeNullOrEmpty
-        $osDetails | Where-Object { $_.Contains('NAME="Microsoft Azure Linux"') } | Should -Not -BeNullOrEmpty
+        $osDetails | Where-Object { $_.Contains('VERSION_ID="3.0"') } | Should-NotBeNull
+        $osDetails | Where-Object { $_.Contains('NAME="Microsoft Azure Linux"') } | Should-NotBeNull
     }
 
     It "Static Versions" {
         # These programs are installed explicitly with specific versions
-        $script:pmap["Node.JS"].Version | Should -Be '24.14.1'
-        $script:pmap["PowerShell"].Version | Should -BeLike '7.6*'
+        $script:pmap["Node.JS"].Version | Should-Be '24.14.1'
+        $script:pmap["PowerShell"].Version | Should-BeLikeString '7.6*'
     }
 
     It "Some Versions Installed" {
@@ -28,16 +28,16 @@ Describe "Various programs installed with expected versions" {
 
         $script:packages | ? Type -eq "Special" | % {
             $name = $_.Name
-            $_.Version | Should -Not -BeNullOrEmpty -Because "$name should be present"
-            $_.Version | Should -Not -Be "Error" -Because "Error occurred running $name to determine version"
-            $_.Version | Should -Not -Be "Unknown" -Because "Could not parse version info for $name"
+            $_.Version | Should-NotBeNull -Because "$name should be present"
+            $_.Version | Should-NotBe "Error" -Because "Error occurred running $name to determine version"
+            $_.Version | Should-NotBe "Unknown" -Because "Could not parse version info for $name"
         }
     }
 
     It "startupscript" {
         $pwshPath = which pwsh
         $startupScriptPath = Join-Path (Split-Path $pwshPath) 'PSCloudShellStartup.ps1'
-        Test-Path $startupScriptPath | Should -Be $true
+        Test-Path $startupScriptPath | Should-BeTrue
     }
 
     It "Compare bash commands to baseline" {
@@ -60,27 +60,27 @@ Describe "Various programs installed with expected versions" {
         $specialmatcher = ($special | % { "($_)" }) -join "|"
 
         $missing = ($command_diffs | ? { $_ -like "<*" } | % { $_.Replace("< ", "") } | ? { $_ -notmatch $specialmatcher }) -join ","
-        $missing | Should -Be "" -Because "Commands '$missing' should be installed on the path but were not found. No commands should have been removed unexpectedly. If one really should be deleted, remove it from command_list"
+        $missing | Should-Be "" -Because "Commands '$missing' should be installed on the path but were not found. No commands should have been removed unexpectedly. If one really should be deleted, remove it from command_list"
 
         $added = ($command_diffs | ? { $_ -like ">*" } | % { $_.Replace("> ", "") } | ? { $_ -notmatch $specialmatcher }) -join ","
-        $added | Should -Be "" -Because "Commands '$added' were unexpectedly found on the path. Probably this is good, in which case add them to command_list"
+        $added | Should-Be "" -Because "Commands '$added' were unexpectedly found on the path. Probably this is good, in which case add them to command_list"
 
     }
 
     It "has local paths in `$PATH" {
         $paths = ($env:PATH).split(":")
-        $paths | Should -Contain "~/bin"
-        $paths | Should -Contain "~/.local/bin"
+        $paths | Should-ContainCollection "~/bin"
+        $paths | Should-ContainCollection "~/.local/bin"
     }
 
     It "Ansible pwsh has modules" {
-        Test-Path -Path "/usr/share/ansible/collections/ansible_collections/azure/azcollection/" | Should -Be $true
+        Test-Path -Path "/usr/share/ansible/collections/ansible_collections/azure/azcollection/" | Should-BeTrue
         $process = Start-Process -FilePath /opt/ansible/bin/python -ArgumentList "-c `"import msrest`"" -Wait -PassThru
-        $process.ExitCode | Should -Be 0
+        $process.ExitCode | Should-Be 0
     }
 
     It "Has various environment vars" {
-        $env:AZUREPS_HOST_ENVIRONMENT | Should -Be "cloud-shell/1.0"
+        $env:AZUREPS_HOST_ENVIRONMENT | Should-Be "cloud-shell/1.0"
     }
 }
 
@@ -100,36 +100,36 @@ Describe "PowerShell Modules" {
 
         $special = @("PSReadLine")
 
-        (Get-Module -ListAvailable | Group-Object Name | Where-Object { $_.Count -gt 1 } ) | Where-Object { $_.Name -notin $special } | Should -Be $null
+        (Get-Module -ListAvailable | Group-Object Name | Where-Object { $_.Count -gt 1 } ) | Where-Object { $_.Name -notin $special } | Should-BeNull
 
     }
 
     It "Az PowerShell Module" {
 
         $module = Get-InstalledModule -Name Az -AllVersions
-        $module | Should -Not -BeNullOrEmpty
+        $module | Should-NotBeNull
     }
 
     It "Az.Accounts PowerShell Module" {
 
         $module = Get-InstalledModule -Name Az.Accounts -AllVersions
-        $module | Should -Not -BeNullOrEmpty
+        $module | Should-NotBeNull
     }
 
     It "Az.Resources PowerShell Module" {
 
         $module = Get-InstalledModule -Name Az.Resources -AllVersions
-        $module | Should -Not -BeNullOrEmpty
+        $module | Should-NotBeNull
     }
 
     It "SHiPS PowerShell Module" {
 
         $module = Get-InstalledModule -Name SHiPS -AllVersions
-        $module | Should -Not -BeNullOrEmpty
-        $module.Repository | Should -Be "PSGallery"
+        $module | Should-NotBeNull
+        $module.Repository | Should-Be "PSGallery"
 
         # SHiPS module version must be 0.*.*.* or greater
-        $module.Version -like "0.*.*" | Should -Be $true
+        $module.Version -like "0.*.*" | Should-BeTrue
 
     }
 
@@ -139,63 +139,63 @@ Describe "PowerShell Modules" {
         # Due to Gallery limitation of handling FullClr/CoreClr dependencies
         # See https://msazure.visualstudio.com/One/_queries/edit/2364469/?fullScreen=false
         $module = Get-Module -Name AzurePSDrive -ListAvailable
-        $module | Should -Not -BeNullOrEmpty
+        $module | Should-NotBeNull
 
         # AzurePSDrive module version must be 0.9.*.* or greater
-        $module.Version.Major -eq 0 | Should -Be $true
-        $module.Version.Minor -ge 9 | Should -Be $true
+        $module.Version.Major -eq 0 | Should-BeTrue
+        $module.Version.Minor -ge 9 | Should-BeTrue
 
     }
 
     It "PSCloudShellUtility PowerShell Module" {
 
         $module = Get-Module -Name PSCloudShellUtility -ListAvailable
-        $module | Should -Not -BeNullOrEmpty
+        $module | Should-NotBeNull
 
         # PSCloudShellUtility module version must be 0.*.*.* or greater
-        $module.Version -like "0.*.*" | Should -Be $true
+        $module.Version -like "0.*.*" | Should-BeTrue
 
     }
 
     It "PowerBI PowerShell Module" {
 
         $module = Get-Module -Name MicrosoftPowerBIMgmt -ListAvailable
-        $module | Should -Not -BeNullOrEmpty
+        $module | Should-NotBeNull
 
         # MicrosoftPowerBIMgmt module version must be 1.*.* or greater
-        $module.Version -like "1.*.*" | Should -Be $true
+        $module.Version -like "1.*.*" | Should-BeTrue
 
     }
 
     It "GuestConfiguration PowerShell Module" {
 
         $module = Get-Module -Name GuestConfiguration -ListAvailable
-        $module | Should -Not -BeNullOrEmpty
+        $module | Should-NotBeNull
 
         # GuestConfiguration module version must be 0.*.* or greater
-        $module.Version -like "4.*.*" | Should -Be $true
+        $module.Version -like "4.*.*" | Should-BeTrue
     }
 
     It "MicrosoftTeams PowerShell Module" {
 
         $module = Get-Module -Name MicrosoftTeams -ListAvailable
-        $module | Should -Not -BeNullOrEmpty
+        $module | Should-NotBeNull
 
         # MicrosoftTeams module should have at least one command
-        (Get-Command * -Module MicrosoftTeams).Count -ge 1 | Should -Be $true
+        (Get-Command * -Module MicrosoftTeams).Count -ge 1 | Should-BeTrue
     }
 
     It "Microsoft.PowerShell.SecretManagement PowerShell Module" {
 
         $module = Get-Module -Name 'Microsoft.PowerShell.SecretManagement' -ListAvailable
-        $module | Should -Not -BeNullOrEmpty
+        $module | Should-NotBeNull
 
     }
 
     It "Microsoft.PowerShell.SecretStore PowerShell Module" {
 
         $module = Get-Module -Name 'Microsoft.PowerShell.SecretStore' -ListAvailable
-        $module | Should -Not -BeNullOrEmpty
+        $module | Should-NotBeNull
 
     }
 
@@ -217,10 +217,10 @@ Describe "PowerShell Modules" {
         param($ModuleName)
         try {
             Import-Module $ModuleName -Force -ErrorAction Stop -ErrorVariable ev
-            $ev | Should -BeNullOrEmpty
+            $ev | Should-BeFalsy
         }
         catch {
-            "Unexpected exception thrown: $_" | Should -BeNullOrEmpty
+            "Unexpected exception thrown: $_" | Should-BeEmptyString
         }
 
     }
@@ -234,7 +234,7 @@ Describe "PowerShell Modules" {
             AzureAD.Standard.Preview\Connect-AzureAD -Identity -TenantId 0
         }
         catch {
-            "Unexpected exception thrown: $_" | Should -BeNullOrEmpty
+            "Unexpected exception thrown: $_" | Should-BeEmptyString
         }
 
     }

--- a/tests/Root.Tests.ps1
+++ b/tests/Root.Tests.ps1
@@ -1,6 +1,6 @@
 Import-Module Pester
 
-Describe "Tests that check things not available to the limited user" {
+Describe "Tests that check things not available to the limited user" -Tag "RootUser" {
 
     It "Powershell warmup script is available and works" {
 

--- a/tests/Root.Tests.ps1
+++ b/tests/Root.Tests.ps1
@@ -4,8 +4,8 @@ Describe "Tests that check things not available to the limited user" {
 
     It "Powershell warmup script is available and works" {
 
-        Test-Path "/usr/cloudshell/linux/powershell/Invoke-PreparePowerShell.ps1"  | Should -Be $true
+        Test-Path "/usr/cloudshell/linux/powershell/Invoke-PreparePowerShell.ps1"  | Should-BeTrue
         Invoke-Expression -Command "/usr/cloudshell/linux/powershell/Invoke-PreparePowerShell.ps1" -ErrorVariable myerr
-        $myerr | Should -BeNullOrEmpty
+        $myerr | Should-BeFalsy
     }
 }

--- a/tests/root-tests.ps1
+++ b/tests/root-tests.ps1
@@ -7,7 +7,13 @@ $ProgressPreference = "SilentlyContinue"
 Push-Location /tests
 try {
 	Install-Module -Name Pester -MinimumVersion 6.0.0 -MaximumVersion 6.999.999 -Force
-	Invoke-Pester -CI -Path Root.Tests.ps1
+
+	$config = New-PesterConfiguration
+	$config.TestResult.Enabled = $false
+	$config.Filter.Tag = "RootUser" # only run tests tagged StandardUser
+	$config.Output.CIFormat = "GithubActions"
+
+	Invoke-Pester -Configuration $config
 } finally {
 	Pop-Location
 }

--- a/tests/root-tests.ps1
+++ b/tests/root-tests.ps1
@@ -10,7 +10,7 @@ try {
 
 	$config = New-PesterConfiguration
 	$config.TestResult.Enabled = $false
-	$config.Filter.Tag = "RootUser" # only run tests tagged StandardUser
+	$config.Filter.Tag = "RootUser" 
 	$config.Output.CIFormat = "GithubActions"
 
 	Invoke-Pester -Configuration $config

--- a/tests/root-tests.ps1
+++ b/tests/root-tests.ps1
@@ -6,7 +6,7 @@ $ProgressPreference = "SilentlyContinue"
 
 Push-Location /tests
 try {
-	Install-Module -Name Pester -Force
+	Install-Module -Name Pester -MinimumVersion 6.0.0 -MaximumVersion 6.999.999 -Force
 	Invoke-Pester -CI -Path Root.Tests.ps1
 } finally {
 	Pop-Location

--- a/tests/root-tests.ps1
+++ b/tests/root-tests.ps1
@@ -4,6 +4,10 @@
 $ErrorActionPreference = "Stop"
 $ProgressPreference = "SilentlyContinue"
 
-cd /tests
-Install-Module -Name Pester -Force
-Invoke-Pester -Script Root.Tests.ps1
+Push-Location /tests
+try {
+	Install-Module -Name Pester -Force
+	Invoke-Pester Root.Tests.ps1
+} finally {
+	Pop-Location
+}

--- a/tests/root-tests.ps1
+++ b/tests/root-tests.ps1
@@ -7,7 +7,7 @@ $ProgressPreference = "SilentlyContinue"
 Push-Location /tests
 try {
 	Install-Module -Name Pester -Force
-	Invoke-Pester Root.Tests.ps1
+	Invoke-Pester -CI -Path Root.Tests.ps1
 } finally {
 	Pop-Location
 }

--- a/tests/root-tests.ps1
+++ b/tests/root-tests.ps1
@@ -6,6 +6,7 @@ $ProgressPreference = "SilentlyContinue"
 
 Push-Location /tests
 try {
+	# Pester is also installed in `test.sh` - make sure that is using the same version as here.
 	Install-Module -Name Pester -MinimumVersion 6.0.0 -MaximumVersion 6.999.999 -Force
 
 	$config = New-PesterConfiguration

--- a/tests/test.ps1
+++ b/tests/test.ps1
@@ -4,5 +4,15 @@
 $ErrorActionPreference = "Stop"
 $ProgressPreference = "SilentlyContinue"
 
-cd /tests
-Invoke-Pester -CI -Path PSinLinuxCloudShellImage.Tests.ps1
+Push-Location /tests
+try {
+	$config = New-PesterConfiguration
+	$config.TestResult.Enabled = $false
+	$config.Filter.Tag = "StandardUser" # only run tests tagged StandardUser
+	$config.Output.CIFormat = "GithubActions"
+
+	Invoke-Pester -Configuration $config
+} finally {
+	Pop-Location
+}
+

--- a/tests/test.ps1
+++ b/tests/test.ps1
@@ -8,7 +8,7 @@ Push-Location /tests
 try {
 	$config = New-PesterConfiguration
 	$config.TestResult.Enabled = $false
-	$config.Filter.Tag = "StandardUser" # only run tests tagged StandardUser
+	$config.Filter.Tag = "CloudShellUser"
 	$config.Output.CIFormat = "GithubActions"
 
 	Invoke-Pester -Configuration $config

--- a/tests/test.ps1
+++ b/tests/test.ps1
@@ -5,4 +5,4 @@ $ErrorActionPreference = "Stop"
 $ProgressPreference = "SilentlyContinue"
 
 cd /tests
-Invoke-Pester -CI -Script PSinLinuxCloudShellImage.Tests.ps1
+Invoke-Pester -CI -Path PSinLinuxCloudShellImage.Tests.ps1

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -15,7 +15,8 @@ fi
 echo "running root-level tests"
 pwsh /tests/root-tests.ps1
 
-pwsh -c "Install-Module Pester -Force -Scope AllUsers"
+	# Pester is also installed in `root-tests.ps1` - make sure that is using the same version as here.
+pwsh -c "Install-Module Pester -MinimumVersion 6.0.0 -MaximumVersion 6.999.999 -Force -Scope AllUsers"
 
 echo "running tests as csuser"
 runuser -u csuser pwsh /tests/test.ps1


### PR DESCRIPTION
In Pester v5, the parameters for `Invoke-Pester` [were changed](https://pester.dev/docs/migrations/breaking-changes-in-v5) to a new format, with a backwards compatibility switch to maintain behavior. That backwards compatibility was [removed in v6](https://pester.dev/docs/migrations/v5-to-v6).

This runs the v4 -> v5, v5 -> v6 migration guides (via copilot) to update the test code to latest. The `Install-Module Pester` was also updated to keep us in v6 to avoid future unexpected breaks.